### PR TITLE
feat: support wasi by tweaking cfg attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,13 @@ string_cache_codegen = "0.5"
 [features]
 node = ["napi", "napi-derive", "napi-build"]
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target = "wasm32-unknown-unknown")'.dependencies]
 chrono = { version = "0.4", features = ["wasmbind"] }
 js-sys = "0.3"
 serde-wasm-bindgen = "0.3"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(target = "wasm32-unknown-unknown"))'.dependencies]
 chrono = "0.4"
 
 [patch.crates-io]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,11 +68,11 @@
 
 use parser::parse_browserslist_query;
 use std::cmp::Ordering;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target = "wasm32-unknown-unknown")]
 pub use wasm::browserslist;
 pub use {error::Error, opts::Opts, queries::Distrib};
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target = "wasm32-unknown-unknown"))]
 mod config;
 mod data;
 mod error;
@@ -84,7 +84,7 @@ mod queries;
 mod semver;
 #[cfg(test)]
 mod test;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target = "wasm32-unknown-unknown")]
 mod wasm;
 
 /// Resolve browserslist queries.
@@ -168,7 +168,7 @@ where
 /// // when no config found, it use `defaults` query
 /// assert!(!execute(&Opts::new()).unwrap().is_empty());
 /// ```
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target = "wasm32-unknown-unknown"))]
 pub fn execute(opts: &Opts) -> Result<Vec<Distrib>, Error> {
     resolve(config::load(opts)?, opts)
 }

--- a/src/queries/browserslist_config.rs
+++ b/src/queries/browserslist_config.rs
@@ -2,12 +2,12 @@ use super::QueryResult;
 use crate::opts::Opts;
 
 pub(super) fn browserslist_config(opts: &Opts) -> QueryResult {
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target = "wasm32-unknown-unknown")]
     {
         crate::resolve(["defaults"], opts)
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target = "wasm32-unknown-unknown"))]
     {
         crate::execute(opts)
     }

--- a/src/queries/current_node.rs
+++ b/src/queries/current_node.rs
@@ -2,7 +2,7 @@ use super::{Distrib, QueryResult};
 use crate::error::Error;
 
 pub(super) fn current_node() -> QueryResult {
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target = "wasm32-unknown-unknown")]
     {
         use js_sys::{global, Reflect};
 
@@ -17,7 +17,7 @@ pub(super) fn current_node() -> QueryResult {
         Ok(vec![Distrib::new("node", version)])
     }
 
-    #[cfg(all(not(target_arch = "wasm32"), feature = "node"))]
+    #[cfg(all(not(target = "wasm32-unknown-unknown"), feature = "node"))]
     {
         use crate::node::CURRENT_NODE;
 
@@ -28,7 +28,7 @@ pub(super) fn current_node() -> QueryResult {
         )])
     }
 
-    #[cfg(all(not(target_arch = "wasm32"), not(feature = "node")))]
+    #[cfg(all(not(target = "wasm32-unknown-unknown"), not(feature = "node")))]
     {
         use std::process::Command;
 


### PR DESCRIPTION
Adds support for [wasi](https://wasi.dev/). Previously the crate could be compiled to wasi, but still relied on `wasm-bindgen` to check for the current node environment so it could not be used outside of a JS runtime.

I am making this PR to try to get [swc](https://github.com/swc-project/swc), which depends on this crate, to run to wasi but this is a blocking issue. I might not be considering some use case but I'm willing to make any requested changes :)