### PR TITLE
chore: use edition=2021 in all crates

### DIFF
--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -2,7 +2,7 @@
 name = "browserslist-data"
 version = "0.1.0"
 authors = ["Pig Fang <g-plane@hotmail.com>"]
-edition = "2024"
+edition = "2021"
 description = "Data for browserslist-rs."
 repository = "https://github.com/browserslist/browserslist-rs"
 license = "MIT"


### PR DESCRIPTION
Closes https://github.com/browserslist/browserslist-rs/issues/34

No need for edition 2024, this just forces downstream users of this crate to upgrade unnecessarily.