### PR TITLE
feat: implement baseline query

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ The features below aren't supported currently:
 
 -   Custom usage like `> 0.5% in my stats`.
 -   Custom usage like `cover 99.5% in my stats`.
--   Baseline queries added in [browserslist v4.26.0](https://github.com/browserslist/browserslist/releases/tag/4.26.0) like `baseline widely available`.
 
 ## Local development setup
 

--- a/data/src/baseline.rs
+++ b/data/src/baseline.rs
@@ -3,6 +3,8 @@
 //!
 //! [`baseline-browser-mapping`]: https://www.npmjs.com/package/baseline-browser-mapping
 
+use crate::{decode_browser_name, utils::PooledStr};
+
 include!("generated/baseline.rs");
 
 /// caniuse names of the seven core Baseline browsers; the remaining browsers
@@ -17,20 +19,24 @@ pub fn is_core_browser(name: &str) -> bool {
 
 /// All browsers tracked by the Baseline dataset, by caniuse name.
 pub fn browsers() -> impl Iterator<Item = &'static str> {
-    BASELINE_BROWSERS.iter().copied()
+    BASELINE_BROWSERS.iter().map(|&id| decode_browser_name(id))
 }
 
 /// Minimum compatible versions (by caniuse browser name) for the Baseline
-/// feature set as of `cutoff_date`, a `YYYY-MM-DD` baseline-low threshold
-/// (the query date minus 30 months for widely-available queries).
+/// feature set as of `cutoff_date`, a baseline-low threshold encoded as
+/// decimal `yyyymmdd` (the query date minus 30 months for widely-available
+/// queries).
 ///
 /// Returns `None` if the date predates the first Baseline feature; every
 /// version of every browser is considered compatible in that case.
 pub fn min_versions_on(
-    cutoff_date: &str,
+    cutoff_date: u32,
 ) -> Option<impl Iterator<Item = (&'static str, &'static str)>> {
-    let index = BASELINE_TIMELINE.partition_point(|(date, _)| *date <= cutoff_date);
-    index
-        .checked_sub(1)
-        .map(|index| BASELINE_TIMELINE[index].1.iter().copied())
+    let index = BASELINE_TIMELINE.partition_point(|(date, ..)| *date <= cutoff_date);
+    index.checked_sub(1).map(|index| {
+        let (_, start, end) = BASELINE_TIMELINE[index];
+        BASELINE_VERSIONS[usize::from(start)..usize::from(end)]
+            .iter()
+            .map(|(id, version)| (decode_browser_name(*id), version.as_str()))
+    })
 }

--- a/data/src/baseline.rs
+++ b/data/src/baseline.rs
@@ -1,0 +1,36 @@
+//! Baseline browser data, generated from the [`baseline-browser-mapping`]
+//! npm package's Baseline support timeline.
+//!
+//! [`baseline-browser-mapping`]: https://www.npmjs.com/package/baseline-browser-mapping
+
+include!("generated/baseline.rs");
+
+/// caniuse names of the seven core Baseline browsers; the remaining browsers
+/// in the dataset are downstream browsers sharing a core browser's engine.
+static CORE_BROWSERS: &[&str] = &[
+    "and_chr", "and_ff", "chrome", "edge", "firefox", "ios_saf", "safari",
+];
+
+pub fn is_core_browser(name: &str) -> bool {
+    CORE_BROWSERS.contains(&name)
+}
+
+/// All browsers tracked by the Baseline dataset, by caniuse name.
+pub fn browsers() -> impl Iterator<Item = &'static str> {
+    BASELINE_BROWSERS.iter().copied()
+}
+
+/// Minimum compatible versions (by caniuse browser name) for the Baseline
+/// feature set as of `cutoff_date`, a `YYYY-MM-DD` baseline-low threshold
+/// (the query date minus 30 months for widely-available queries).
+///
+/// Returns `None` if the date predates the first Baseline feature; every
+/// version of every browser is considered compatible in that case.
+pub fn min_versions_on(
+    cutoff_date: &str,
+) -> Option<impl Iterator<Item = (&'static str, &'static str)>> {
+    let index = BASELINE_TIMELINE.partition_point(|(date, _)| *date <= cutoff_date);
+    index
+        .checked_sub(1)
+        .map(|index| BASELINE_TIMELINE[index].1.iter().copied())
+}

--- a/data/src/caniuse/features.rs
+++ b/data/src/caniuse/features.rs
@@ -46,7 +46,7 @@ impl Feature {
 
 impl VersionList {
     pub fn get(&self, version: &str) -> Option<u8> {
-        let range = (self.0.0.get() as usize)..(self.0.1.get() as usize);
+        let range = (self.0 .0.get() as usize)..(self.0 .1.get() as usize);
         let index = FEATURES_STAT_VERSION_STORE[range.clone()]
             .binary_search_by_key(&version, |s| PooledStr(s.get()).as_str())
             .ok()?;

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod baseline;
 pub mod caniuse;
 pub mod electron;
 pub mod node;

--- a/data/src/utils.rs
+++ b/data/src/utils.rs
@@ -49,7 +49,7 @@ pub(super) struct PooledStr(pub(super) u32);
 
 impl PooledStr {
     pub fn as_str(&self) -> &'static str {
-        static STRPOOL: &str = include_str!("generated/caniuse-strpool.bin");
+        static STRPOOL: &str = include_str!("generated/strpool.bin");
 
         // 24bit offset and 8bit len
         let offset = self.0 & ((1 << 24) - 1);

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -620,9 +620,11 @@ process.stdout.write(JSON.stringify(timeline));
     for (date, snapshot) in &events {
         let date: u32 = date.replace('-', "").parse()?;
         let start: u16 = version_entries.len().try_into()?;
-        for (browser, version) in snapshot {
-            version_entries.push((encode_browser_name(browser), strpool.insert(version)));
-        }
+        version_entries.extend(
+            snapshot
+                .iter()
+                .map(|(browser, version)| (encode_browser_name(browser), strpool.insert(version))),
+        );
         let end: u16 = version_entries.len().try_into()?;
         timeline_entries.push((date, start, end));
     }
@@ -687,7 +689,7 @@ impl StrPool {
 
         let offset = self.pool.len();
         self.pool.push_str(s);
-        let len: u8 = (self.pool.len() - offset).try_into().unwrap();
+        let len: u8 = s.len().try_into().unwrap();
         let offset: u32 = offset.try_into().unwrap();
 
         if offset > (1 << 24) {

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -3,7 +3,6 @@ use indexmap::IndexMap;
 use quote::quote;
 use serde::{Deserialize, Serialize};
 use std::{
-    borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
     io::{self, Write},
@@ -65,8 +64,11 @@ fn main() -> Result<()> {
     build_electron_to_chromium()?;
     build_node_versions()?;
     build_node_release_schedule()?;
-    build_caniuse()?;
-    build_baseline()?;
+
+    let mut strpool = StrPool::default();
+    build_caniuse(&mut strpool)?;
+    build_baseline(&mut strpool)?;
+    fs::write(format!("{OUT_DIR}/strpool.bin"), strpool.pool.as_bytes())?;
 
     Ok(())
 }
@@ -206,11 +208,9 @@ fn build_node_release_schedule() -> Result<()> {
     Ok(())
 }
 
-fn build_caniuse() -> Result<()> {
+fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
     let data = parse_caniuse_global()?;
     let region_data = parse_caniuse_regions()?;
-
-    let mut strpool = StrPool::default();
 
     // caniuse browsers
     {
@@ -416,19 +416,19 @@ fn build_caniuse() -> Result<()> {
                 let agent = data.agents.get(name).unwrap();
                 for (version, &usage) in stat {
                     let version = if version.as_str() == "0" {
-                        Cow::Borrowed(&*agent.version_list.last().unwrap().version)
+                        &agent.version_list.last().unwrap().version
                     } else {
-                        Cow::Owned(version.clone())
+                        version
                     };
 
-                    let version_str_id = strpool.insert_cow(version);
+                    let version_str_id = strpool.insert(version);
                     usages.push((encode_browser_name(name), version_str_id, usage));
                 }
             }
             let end = usages.len();
             usages[start..end].sort_by(|(_, _, a), (_, _, b)| b.total_cmp(a));
 
-            let region_str_id = strpool.insert_cow(Cow::Owned(region_name.clone()));
+            let region_str_id = strpool.insert(region_name);
             region_usages.push((region_str_id, start, end));
         }
 
@@ -483,11 +483,6 @@ fn build_caniuse() -> Result<()> {
             }.to_string()
         )?;
     }
-
-    fs::write(
-        format!("{OUT_DIR}/caniuse-strpool.bin"),
-        strpool.pool.as_bytes(),
-    )?;
 
     Ok(())
 }
@@ -547,7 +542,7 @@ process.stdout.write(JSON.stringify(result));
     Ok(serde_json::from_str(&json)?)
 }
 
-fn build_baseline() -> Result<()> {
+fn build_baseline(strpool: &mut StrPool) -> Result<()> {
     #[derive(Deserialize)]
     struct TimelineEvent {
         date: String,
@@ -617,18 +612,37 @@ process.stdout.write(JSON.stringify(timeline));
         }
     }
 
-    let browser_tokens = browsers.iter().map(|name| quote! { #name });
-    let event_tokens = events.iter().map(|(date, snapshot)| {
-        let entries = snapshot
-            .iter()
-            .map(|(browser, version)| quote! { (#browser, #version) });
-        quote! { (#date, &[#(#entries),*]) }
+    // Flatten the snapshots into one array of (browser id, pooled version)
+    // and index into it per event, keyed by the date as a decimal `yyyymmdd`.
+    // This keeps the tables free of pointers (and their relocations).
+    let mut version_entries: Vec<(u8, u32)> = Vec::new();
+    let mut timeline_entries: Vec<(u32, u16, u16)> = Vec::new();
+    for (date, snapshot) in &events {
+        let date: u32 = date.replace('-', "").parse()?;
+        let start: u16 = version_entries.len().try_into()?;
+        for (browser, version) in snapshot {
+            version_entries.push((encode_browser_name(browser), strpool.insert(version)));
+        }
+        let end: u16 = version_entries.len().try_into()?;
+        timeline_entries.push((date, start, end));
+    }
+
+    let browser_tokens = browsers.iter().map(|name| {
+        let id = encode_browser_name(name);
+        quote! { #id }
     });
+    let version_tokens = version_entries
+        .iter()
+        .map(|(browser, version)| quote! { (#browser, PooledStr(#version)) });
+    let timeline_tokens = timeline_entries
+        .iter()
+        .map(|(date, start, end)| quote! { (#date, #start, #end) });
     fs::write(
         format!("{OUT_DIR}/baseline.rs"),
         quote! {
-            static BASELINE_BROWSERS: &[&str] = &[#(#browser_tokens),*];
-            static BASELINE_TIMELINE: &[(&str, &[(&str, &str)])] = &[#(#event_tokens),*];
+            static BASELINE_BROWSERS: &[u8] = &[#(#browser_tokens),*];
+            static BASELINE_VERSIONS: &[(u8, PooledStr)] = &[#(#version_tokens),*];
+            static BASELINE_TIMELINE: &[(u32, u16, u16)] = &[#(#timeline_tokens),*];
         }
         .to_string(),
     )?;
@@ -660,29 +674,29 @@ fn write_u32(path: String, iter: impl Iterator<Item = u32>) -> io::Result<usize>
 }
 
 #[derive(Default)]
-struct StrPool<'s> {
+struct StrPool {
     pool: String,
-    map: HashMap<Cow<'s, str>, u32>,
+    map: HashMap<String, u32>,
 }
 
-impl<'s> StrPool<'s> {
-    pub fn insert(&mut self, s: &'s str) -> u32 {
-        self.insert_cow(Cow::Borrowed(s))
-    }
+impl StrPool {
+    pub fn insert(&mut self, s: &str) -> u32 {
+        if let Some(id) = self.map.get(s) {
+            return *id;
+        }
 
-    pub fn insert_cow(&mut self, s: Cow<'s, str>) -> u32 {
-        *self.map.entry(s.clone()).or_insert_with(|| {
-            let offset = self.pool.len();
-            self.pool.push_str(&s);
-            let len: u8 = (self.pool.len() - offset).try_into().unwrap();
-            let offset: u32 = offset.try_into().unwrap();
+        let offset = self.pool.len();
+        self.pool.push_str(s);
+        let len: u8 = (self.pool.len() - offset).try_into().unwrap();
+        let offset: u32 = offset.try_into().unwrap();
 
-            if offset > (1 << 24) {
-                panic!("string too large");
-            }
+        if offset > (1 << 24) {
+            panic!("string too large");
+        }
 
-            offset | (u32::from(len) << 24)
-        })
+        let id = offset | (u32::from(len) << 24);
+        self.map.insert(s.to_owned(), id);
+        id
     }
 
     pub fn get(&self, id: u32) -> &str {

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     fs,
     io::{self, Write},
 };
@@ -66,6 +66,7 @@ fn main() -> Result<()> {
     build_node_versions()?;
     build_node_release_schedule()?;
     build_caniuse()?;
+    build_baseline()?;
 
     Ok(())
 }
@@ -121,8 +122,9 @@ fn build_node_versions() -> Result<()> {
 
     let path = format!("{OUT_DIR}/node-versions.rs");
 
-    let releases: Vec<NodeRelease> =
-        serde_json::from_slice(&fs::read("node_modules/node-releases/data/processed/envs.json")?)?;
+    let releases: Vec<NodeRelease> = serde_json::from_slice(&fs::read(
+        "node_modules/node-releases/data/processed/envs.json",
+    )?)?;
 
     let versions = releases.into_iter().map(|release| release.version);
     fs::write(
@@ -491,7 +493,8 @@ fn build_caniuse() -> Result<()> {
 }
 
 fn parse_caniuse_global() -> Result<Caniuse> {
-    let json = run_node(r#"
+    let json = run_node(
+        r#"
 const { agents } = require('./node_modules/caniuse-lite/dist/unpacker/agents');
 const featuresMap = require('./node_modules/caniuse-lite/data/features');
 const unpackFeature = require('./node_modules/caniuse-lite/dist/unpacker/feature');
@@ -512,12 +515,14 @@ for (const [name, featureModule] of Object.entries(featuresMap)) {
     result.data[name] = { stats: unpacked.stats };
 }
 process.stdout.write(JSON.stringify(result));
-"#)?;
+"#,
+    )?;
     Ok(serde_json::from_str(&json)?)
 }
 
 fn parse_caniuse_regions() -> Result<BTreeMap<String, BTreeMap<String, BTreeMap<String, f32>>>> {
-    let json = run_node(r#"
+    let json = run_node(
+        r#"
 const fs = require('fs');
 const path = require('path');
 const browsersMap = require('./node_modules/caniuse-lite/data/browsers');
@@ -537,8 +542,98 @@ for (const file of files) {
     result[name] = regionData;
 }
 process.stdout.write(JSON.stringify(result));
-"#)?;
+"#,
+    )?;
     Ok(serde_json::from_str(&json)?)
+}
+
+fn build_baseline() -> Result<()> {
+    #[derive(Deserialize)]
+    struct TimelineEvent {
+        date: String,
+        browsers: Vec<TimelineBrowserVersion>,
+    }
+
+    #[derive(Deserialize)]
+    struct TimelineBrowserVersion {
+        browser: String,
+        version: String,
+    }
+
+    let json = run_node(
+        r#"
+const bbm = require('baseline-browser-mapping');
+const timeline = bbm.getTimeline({
+    listAllBrowsers: true,
+    includeDownstreamBrowsers: true,
+    includeKaiOS: true,
+});
+process.stdout.write(JSON.stringify(timeline));
+"#,
+    )?;
+    let timeline: Vec<TimelineEvent> = serde_json::from_str(&json)?;
+
+    // Map baseline-browser-mapping browser names to caniuse browser names,
+    // dropping browsers that caniuse doesn't track (as browserslist does).
+    let browser_map: HashMap<&str, &str> = [
+        ("chrome", "chrome"),
+        ("chrome_android", "and_chr"),
+        ("edge", "edge"),
+        ("firefox", "firefox"),
+        ("firefox_android", "and_ff"),
+        ("safari", "safari"),
+        ("safari_ios", "ios_saf"),
+        ("webview_android", "android"),
+        ("samsunginternet_android", "samsung"),
+        ("opera_android", "op_mob"),
+        ("opera", "opera"),
+        ("qq_android", "and_qq"),
+        ("uc_android", "and_uc"),
+        ("kai_os", "kaios"),
+    ]
+    .into_iter()
+    .collect();
+
+    let mut browsers = BTreeSet::new();
+    let mut events: Vec<(&str, BTreeMap<&str, &str>)> = Vec::new();
+    for event in &timeline {
+        if let Some((last_date, _)) = events.last() {
+            anyhow::ensure!(*last_date < event.date.as_str(), "timeline must be sorted");
+        }
+        let snapshot: BTreeMap<&str, &str> = event
+            .browsers
+            .iter()
+            .filter_map(|entry| {
+                browser_map
+                    .get(entry.browser.as_str())
+                    .map(|name| (*name, entry.version.as_str()))
+            })
+            .collect();
+        browsers.extend(snapshot.keys().copied());
+        // Events can become identical after dropping unmapped browsers.
+        match events.last() {
+            Some((_, last)) if *last == snapshot => {}
+            _ => events.push((event.date.as_str(), snapshot)),
+        }
+    }
+
+    let browser_tokens = browsers.iter().map(|name| quote! { #name });
+    let event_tokens = events.iter().map(|(date, snapshot)| {
+        let entries = snapshot
+            .iter()
+            .map(|(browser, version)| quote! { (#browser, #version) });
+        quote! { (#date, &[#(#entries),*]) }
+    });
+    fs::write(
+        format!("{OUT_DIR}/baseline.rs"),
+        quote! {
+            static BASELINE_BROWSERS: &[&str] = &[#(#browser_tokens),*];
+            static BASELINE_TIMELINE: &[(&str, &[(&str, &str)])] = &[#(#event_tokens),*];
+        }
+        .to_string(),
+    )?;
+
+    Ok(())
 }
 
 fn run_node(script: &str) -> Result<String> {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "repository": "https://github.com/browserslist/browserslist-rs",
   "devDependencies": {
+    "baseline-browser-mapping": "^2.11.0",
     "browserslist": "^4.28.6",
     "caniuse-lite": "^1.0.30001806",
     "electron-to-chromium": "^1.5.393",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      baseline-browser-mapping:
+        specifier: ^2.11.0
+        version: 2.11.0
       browserslist:
         specifier: ^4.28.6
         version: 4.28.6
@@ -23,8 +26,8 @@ importers:
 
 packages:
 
-  baseline-browser-mapping@2.10.43:
-    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
+  baseline-browser-mapping@2.11.0:
+    resolution: {integrity: sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -58,11 +61,11 @@ packages:
 
 snapshots:
 
-  baseline-browser-mapping@2.10.43: {}
+  baseline-browser-mapping@2.11.0: {}
 
   browserslist@4.28.6:
     dependencies:
-      baseline-browser-mapping: 2.10.43
+      baseline-browser-mapping: 2.11.0
       caniuse-lite: 1.0.30001806
       electron-to-chromium: 1.5.393
       node-releases: 2.0.51

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,6 +12,14 @@ use nom::{
 type PResult<'a, Output> = IResult<&'a str, Output>;
 
 #[derive(Debug, Clone)]
+pub enum BaselineKind<'a> {
+    WidelyAvailable,
+    WidelyAvailableOnDate(&'a str), // "YYYY-MM-DD"
+    NewlyAvailable,
+    Year(u16),
+}
+
+#[derive(Debug, Clone)]
 pub enum QueryAtom<'a> {
     Last {
         count: u16,
@@ -38,6 +46,11 @@ pub enum QueryAtom<'a> {
     Electron(VersionRange<'a>),
     Node(VersionRange<'a>),
     Browser(&'a str, VersionRange<'a>),
+    Baseline {
+        kind: BaselineKind<'a>,
+        downstream: bool,
+        kaios: bool,
+    },
     FirefoxESR,
     OperaMini,
     CurrentNode,
@@ -369,6 +382,72 @@ fn parse_extends(input: &str) -> PResult<QueryAtom> {
     )(input)
 }
 
+fn parse_date_yyyy_mm_dd(input: &str) -> PResult<&str> {
+    recognize(tuple((
+        take_while_m_n(4, 4, |c: char| c.is_ascii_digit()),
+        char('-'),
+        take_while_m_n(2, 2, |c: char| c.is_ascii_digit()),
+        char('-'),
+        take_while_m_n(2, 2, |c: char| c.is_ascii_digit()),
+    )))(input)
+}
+
+fn parse_baseline(input: &str) -> PResult<QueryAtom> {
+    // Grammar (case-insensitive):
+    //   baseline YEAR
+    //   baseline widely available [on YYYY-MM-DD]
+    //   baseline newly available
+    //   … optionally followed by "with downstream", then optionally "including kaios"
+    let (input, _) = pair(tag_no_case("baseline"), space1)(input)?;
+
+    let (input, kind) = alt((
+        map(u16, BaselineKind::Year),
+        map(
+            preceded(
+                pair(
+                    terminated(tag_no_case("widely"), space1),
+                    tag_no_case("available"),
+                ),
+                opt(preceded(
+                    tuple((space1, tag_no_case("on"), space1)),
+                    parse_date_yyyy_mm_dd,
+                )),
+            ),
+            |date| match date {
+                Some(date) => BaselineKind::WidelyAvailableOnDate(date),
+                None => BaselineKind::WidelyAvailable,
+            },
+        ),
+        value(
+            BaselineKind::NewlyAvailable,
+            tuple((tag_no_case("newly"), space1, tag_no_case("available"))),
+        ),
+    ))(input)?;
+
+    let (input, downstream) = opt(tuple((
+        space1,
+        tag_no_case("with"),
+        space1,
+        tag_no_case("downstream"),
+    )))(input)?;
+
+    let (input, kaios) = opt(tuple((
+        space1,
+        tag_no_case("including"),
+        space1,
+        tag_no_case("kaios"),
+    )))(input)?;
+
+    Ok((
+        input,
+        QueryAtom::Baseline {
+            kind,
+            downstream: downstream.is_some(),
+            kaios: kaios.is_some(),
+        },
+    ))
+}
+
 fn parse_unknown(input: &str) -> PResult<QueryAtom> {
     map(
         recognize(many_till(anychar, parse_composition_operator)),
@@ -392,6 +471,7 @@ fn parse_query_atom(input: &str) -> PResult<QueryAtom> {
         parse_current_node,
         parse_maintained_node,
         parse_phantom,
+        parse_baseline,
         parse_browser,
         parse_browserslist_config,
         parse_defaults,

--- a/src/queries/baseline.rs
+++ b/src/queries/baseline.rs
@@ -26,7 +26,7 @@ pub(super) fn baseline(
         BaselineKind::WidelyAvailableOnDate(date) => add_months(parse_date(date), -30),
         BaselineKind::Year(year) => (i32::from(*year), 12, 31),
     };
-    let cutoff = format!("{:04}-{:02}-{:02}", cutoff.0, cutoff.1, cutoff.2);
+    let cutoff = date_key(cutoff);
 
     // KaiOS is only included when downstream browsers are requested as well.
     let is_included = |browser: &str| {
@@ -34,7 +34,7 @@ pub(super) fn baseline(
     };
 
     let mut distribs = Vec::new();
-    match baseline::min_versions_on(&cutoff) {
+    match baseline::min_versions_on(cutoff) {
         Some(min_versions) => {
             for (browser, version) in min_versions {
                 if is_included(browser) {
@@ -63,6 +63,11 @@ pub(super) fn baseline(
         }
     }
     Ok(distribs)
+}
+
+/// Encodes a date as decimal `yyyymmdd`, the key of the Baseline timeline.
+fn date_key((year, month, day): Date) -> u32 {
+    year as u32 * 10000 + month * 100 + day
 }
 
 fn today() -> Date {

--- a/src/queries/baseline.rs
+++ b/src/queries/baseline.rs
@@ -36,29 +36,25 @@ pub(super) fn baseline(
     let mut distribs = Vec::new();
     match baseline::min_versions_on(cutoff) {
         Some(min_versions) => {
-            for (browser, version) in min_versions {
-                if is_included(browser) {
-                    distribs.append(&mut browser_unbounded_range(
-                        browser,
-                        Comparator::GreaterOrEqual,
-                        version,
-                        opts,
-                    )?);
-                }
+            for (browser, version) in min_versions.filter(|(browser, _)| is_included(browser)) {
+                distribs.append(&mut browser_unbounded_range(
+                    browser,
+                    Comparator::GreaterOrEqual,
+                    version,
+                    opts,
+                )?);
             }
         }
         // Before the first Baseline feature, every version of every browser
         // is considered compatible.
         None => {
-            for browser in baseline::browsers() {
-                if is_included(browser) {
-                    distribs.append(&mut browser_unbounded_range(
-                        browser,
-                        Comparator::GreaterOrEqual,
-                        "0",
-                        opts,
-                    )?);
-                }
+            for browser in baseline::browsers().filter(|browser| is_included(browser)) {
+                distribs.append(&mut browser_unbounded_range(
+                    browser,
+                    Comparator::GreaterOrEqual,
+                    "0",
+                    opts,
+                )?);
             }
         }
     }

--- a/src/queries/baseline.rs
+++ b/src/queries/baseline.rs
@@ -1,0 +1,160 @@
+use super::{browser_unbounded_range::browser_unbounded_range, QueryResult};
+use crate::{
+    opts::Opts,
+    parser::{BaselineKind, Comparator},
+};
+use browserslist_data::baseline;
+use chrono::{Datelike, Local};
+
+type Date = (i32, u32, u32);
+
+pub(super) fn baseline(
+    kind: &BaselineKind,
+    downstream: bool,
+    kaios: bool,
+    opts: &Opts,
+) -> QueryResult {
+    // The Baseline timeline is keyed by baseline-low dates, which browserslist
+    // queries with a 30-month "widely available" offset:
+    //   widely available          => today - 30 months
+    //   newly available           => (today + 30 months) - 30 months
+    //   widely available on DATE  => DATE - 30 months
+    //   YEAR                      => end of that year
+    let cutoff = match kind {
+        BaselineKind::WidelyAvailable => add_months(today(), -30),
+        BaselineKind::NewlyAvailable => add_months(add_months(today(), 30), -30),
+        BaselineKind::WidelyAvailableOnDate(date) => add_months(parse_date(date), -30),
+        BaselineKind::Year(year) => (i32::from(*year), 12, 31),
+    };
+    let cutoff = format!("{:04}-{:02}-{:02}", cutoff.0, cutoff.1, cutoff.2);
+
+    // KaiOS is only included when downstream browsers are requested as well.
+    let is_included = |browser: &str| {
+        baseline::is_core_browser(browser) || (downstream && (kaios || browser != "kaios"))
+    };
+
+    let mut distribs = Vec::new();
+    match baseline::min_versions_on(&cutoff) {
+        Some(min_versions) => {
+            for (browser, version) in min_versions {
+                if is_included(browser) {
+                    distribs.append(&mut browser_unbounded_range(
+                        browser,
+                        Comparator::GreaterOrEqual,
+                        version,
+                        opts,
+                    )?);
+                }
+            }
+        }
+        // Before the first Baseline feature, every version of every browser
+        // is considered compatible.
+        None => {
+            for browser in baseline::browsers() {
+                if is_included(browser) {
+                    distribs.append(&mut browser_unbounded_range(
+                        browser,
+                        Comparator::GreaterOrEqual,
+                        "0",
+                        opts,
+                    )?);
+                }
+            }
+        }
+    }
+    Ok(distribs)
+}
+
+fn today() -> Date {
+    let now = Local::now().date_naive();
+    (now.year(), now.month(), now.day())
+}
+
+fn parse_date(date: &str) -> Date {
+    // The "YYYY-MM-DD" shape is guaranteed by the parser.
+    let mut parts = date.split('-').map(|part| part.parse().unwrap());
+    let year = parts.next().unwrap();
+    let month = parts.next().unwrap() as u32;
+    let day = parts.next().unwrap() as u32;
+    (year, month, day)
+}
+
+/// Adds `offset` months to a date with JavaScript `Date.prototype.setMonth`
+/// semantics: a day-of-month past the end of the target month rolls over
+/// into the following month.
+fn add_months((year, month, day): Date, offset: i32) -> Date {
+    let months = year * 12 + month as i32 - 1 + offset;
+    let mut year = months.div_euclid(12);
+    let mut month = months.rem_euclid(12) as u32 + 1;
+    let mut day = day;
+    while day > days_in_month(year, month) {
+        day -= days_in_month(year, month);
+        month += 1;
+        if month > 12 {
+            month = 1;
+            year += 1;
+        }
+    }
+    (year, month, day)
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    match month {
+        4 | 6 | 9 | 11 => 30,
+        2 if (year % 4 == 0 && year % 100 != 0) || year % 400 == 0 => 29,
+        2 => 28,
+        _ => 31,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{opts::Opts, test::run_compare};
+    use test_case::test_case;
+
+    #[test_case("baseline widely available"; "widely")]
+    #[test_case("BASELINE WIDELY AVAILABLE"; "case insensitive widely")]
+    #[test_case("baseline newly available"; "newly")]
+    #[test_case("baseline 2014"; "year before baseline")]
+    #[test_case("baseline 2015"; "year 2015")]
+    #[test_case("baseline 2016"; "year 2016")]
+    #[test_case("baseline 2017"; "year 2017")]
+    #[test_case("baseline 2018"; "year 2018")]
+    #[test_case("baseline 2019"; "year 2019")]
+    #[test_case("baseline 2020"; "year 2020")]
+    #[test_case("baseline 2021"; "year 2021")]
+    #[test_case("baseline 2022"; "year 2022")]
+    #[test_case("baseline 2023"; "year 2023")]
+    #[test_case("baseline 2024"; "year 2024")]
+    #[test_case("baseline 2025"; "year 2025")]
+    #[test_case("baseline widely available on 2018-01-01"; "widely on date before baseline")]
+    #[test_case("baseline widely available on 2021-01-01"; "widely on date 2021-01-01")]
+    #[test_case("baseline widely available on 2023-04-05"; "widely on date 2023-04-05")]
+    #[test_case("baseline widely available on 2024-05-31"; "widely on date with day overflow")]
+    #[test_case("baseline widely available on 2024-06-15"; "widely on date 2024-06-15")]
+    #[test_case("baseline 2022 with downstream"; "year with downstream")]
+    #[test_case("baseline widely available with downstream"; "widely with downstream")]
+    #[test_case("baseline newly available with downstream"; "newly with downstream")]
+    #[test_case("baseline 2020 including kaios"; "kaios without downstream")]
+    #[test_case("baseline 2020 with downstream including kaios"; "year with downstream and kaios")]
+    #[test_case(
+        "baseline widely available on 2024-06-15 with downstream including kaios";
+        "widely on date with downstream and kaios"
+    )]
+    fn valid(query: &str) {
+        run_compare(query, &Opts::default(), None);
+    }
+
+    #[test_case("baseline widely available"; "widely")]
+    #[test_case("baseline 2022 with downstream"; "year with downstream")]
+    fn mobile_to_desktop(query: &str) {
+        run_compare(
+            query,
+            &Opts {
+                mobile_to_desktop: true,
+                ..Default::default()
+            },
+            None,
+        );
+    }
+}

--- a/src/queries/extends.rs
+++ b/src/queries/extends.rs
@@ -48,8 +48,7 @@ fn check_extend_name(pkg: &str) -> Result<(), Error> {
         .unwrap_or(pkg);
     if !(unscoped.starts_with("browserslist-config-")
         || (pkg.starts_with('@')
-            && (unscoped == "browserslist-config"
-                || unscoped.starts_with("browserslist-config/"))))
+            && (unscoped == "browserslist-config" || unscoped.starts_with("browserslist-config/"))))
     {
         return Err(Error::InvalidExtendName(
             "Browserslist config needs `browserslist-config-` prefix.",

--- a/src/queries/firefox_esr.rs
+++ b/src/queries/firefox_esr.rs
@@ -1,9 +1,7 @@
 use super::{Distrib, QueryResult};
 
 pub(super) fn firefox_esr() -> QueryResult {
-    Ok(vec![
-        Distrib::new("firefox", "140"),
-    ])
+    Ok(vec![Distrib::new("firefox", "140")])
 }
 
 #[cfg(test)]

--- a/src/queries/mod.rs
+++ b/src/queries/mod.rs
@@ -8,6 +8,7 @@ use browserslist_data::caniuse;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt::Display};
 
+mod baseline;
 mod browser_accurate;
 mod browser_bounded_range;
 mod browser_unbounded_range;
@@ -209,6 +210,11 @@ pub fn query(atom: QueryAtom, opts: &Opts) -> QueryResult {
         QueryAtom::Browser(name, VersionRange::Accurate(version)) => {
             browser_accurate::browser_accurate(name, version, opts)
         }
+        QueryAtom::Baseline {
+            kind,
+            downstream,
+            kaios,
+        } => baseline::baseline(&kind, downstream, kaios, opts),
         QueryAtom::FirefoxESR => firefox_esr::firefox_esr(),
         QueryAtom::OperaMini => op_mini::op_mini(),
         QueryAtom::CurrentNode => current_node::current_node(),


### PR DESCRIPTION
This PR fixes #40.

```jsonc
{
  "browserslist": ["baseline 2025"] // or "baseline widely available"
}
```

- Added npm dependency `baseline-browser-mapping`
- Added related generate-data scripts, merged string pool with caniuse datas.
- Added related query codes
- Added related tests

