### PR TITLE
perf: improve binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["rlib"]
 
 [features]
 wasm_bindgen = ["chrono/wasmbind", "js-sys"]
+deflate = ["browserslist-data/deflate"]
 
 [dependencies]
 ahash = { workspace = true, features = ["serde"] }

--- a/data/Cargo.toml
+++ b/data/Cargo.toml
@@ -11,9 +11,15 @@ include = [
     "Cargo.toml",
     "src/generated/info.txt",
     "src/generated/**/*.bin",
-    "src/generated/**/*.u32seq",
+    "src/generated/**/*.bin.deflate",
 ]
 
 [dependencies]
 ahash = { workspace = true }
 chrono = { workspace = true }
+miniz_oxide = { version = "0.9.1", optional = true, default-features = false, features = [
+    "with-alloc",
+] }
+
+[features]
+deflate = ["dep:miniz_oxide"]

--- a/data/src/baseline.rs
+++ b/data/src/baseline.rs
@@ -4,8 +4,32 @@
 //! [`baseline-browser-mapping`]: https://www.npmjs.com/package/baseline-browser-mapping
 
 use crate::{decode_browser_name, utils::PooledStr};
+use std::sync::LazyLock;
 
 include!("generated/baseline.rs");
+
+static BASELINE_VERSIONS: LazyLock<Vec<(u8, PooledStr)>> = LazyLock::new(|| {
+    (0..BASELINE_VERSIONS_BROWSER.len())
+        .map(|index| {
+            (
+                BASELINE_VERSIONS_BROWSER[index],
+                BASELINE_VERSIONS_VERSION[index],
+            )
+        })
+        .collect()
+});
+
+static BASELINE_TIMELINE: LazyLock<Vec<(u32, u16, u16)>> = LazyLock::new(|| {
+    (0..BASELINE_TIMELINE_DATE.len())
+        .map(|index| {
+            (
+                BASELINE_TIMELINE_DATE[index],
+                BASELINE_TIMELINE_START[index],
+                BASELINE_TIMELINE_END[index],
+            )
+        })
+        .collect()
+});
 
 /// caniuse names of the seven core Baseline browsers; the remaining browsers
 /// in the dataset are downstream browsers sharing a core browser's engine.

--- a/data/src/baseline.rs
+++ b/data/src/baseline.rs
@@ -3,17 +3,18 @@
 //!
 //! [`baseline-browser-mapping`]: https://www.npmjs.com/package/baseline-browser-mapping
 
-use crate::{caniuse::version_in_table, decode_browser_name, utils::undelta};
+use crate::{blob::Blob, caniuse::version_in_table, decode_browser_name, utils::undelta};
 use std::sync::LazyLock;
 
 include!("generated/baseline.rs");
 
 static BASELINE_VERSIONS: LazyLock<Vec<(u8, &'static str)>> = LazyLock::new(|| {
     BASELINE_VERSIONS_BROWSER
+        .get()
         .iter()
         .zip(crate::caniuse::version_indices(
-            BASELINE_VERSIONS_VERSION_LO,
-            BASELINE_VERSIONS_VERSION_HI,
+            &BASELINE_VERSIONS_VERSION_LO,
+            &BASELINE_VERSIONS_VERSION_HI,
         ))
         .map(|(browser, version)| (*browser, version_in_table(version)))
         .collect()

--- a/data/src/baseline.rs
+++ b/data/src/baseline.rs
@@ -3,22 +3,19 @@
 //!
 //! [`baseline-browser-mapping`]: https://www.npmjs.com/package/baseline-browser-mapping
 
-use crate::{
-    decode_browser_name,
-    utils::{PooledStr, undelta},
-};
+use crate::{caniuse::version_in_table, decode_browser_name, utils::undelta};
 use std::sync::LazyLock;
 
 include!("generated/baseline.rs");
 
-static BASELINE_VERSIONS: LazyLock<Vec<(u8, PooledStr)>> = LazyLock::new(|| {
-    (0..BASELINE_VERSIONS_BROWSER.len())
-        .map(|index| {
-            (
-                BASELINE_VERSIONS_BROWSER[index],
-                BASELINE_VERSIONS_VERSION[index],
-            )
-        })
+static BASELINE_VERSIONS: LazyLock<Vec<(u8, &'static str)>> = LazyLock::new(|| {
+    BASELINE_VERSIONS_BROWSER
+        .iter()
+        .zip(crate::caniuse::version_indices(
+            BASELINE_VERSIONS_VERSION_LO,
+            BASELINE_VERSIONS_VERSION_HI,
+        ))
+        .map(|(browser, version)| (*browser, version_in_table(version)))
         .collect()
 });
 
@@ -65,6 +62,6 @@ pub fn min_versions_on(
         let (_, start, end) = BASELINE_TIMELINE[index];
         BASELINE_VERSIONS[usize::from(start)..usize::from(end)]
             .iter()
-            .map(|(id, version)| (decode_browser_name(*id), version.as_str()))
+            .map(|(id, version)| (decode_browser_name(*id), *version))
     })
 }

--- a/data/src/baseline.rs
+++ b/data/src/baseline.rs
@@ -3,7 +3,10 @@
 //!
 //! [`baseline-browser-mapping`]: https://www.npmjs.com/package/baseline-browser-mapping
 
-use crate::{decode_browser_name, utils::PooledStr};
+use crate::{
+    decode_browser_name,
+    utils::{PooledStr, undelta},
+};
 use std::sync::LazyLock;
 
 include!("generated/baseline.rs");
@@ -20,13 +23,14 @@ static BASELINE_VERSIONS: LazyLock<Vec<(u8, PooledStr)>> = LazyLock::new(|| {
 });
 
 static BASELINE_TIMELINE: LazyLock<Vec<(u32, u16, u16)>> = LazyLock::new(|| {
-    (0..BASELINE_TIMELINE_DATE.len())
-        .map(|index| {
-            (
-                BASELINE_TIMELINE_DATE[index],
-                BASELINE_TIMELINE_START[index],
-                BASELINE_TIMELINE_END[index],
-            )
+    let mut start = 0;
+    undelta(BASELINE_TIMELINE_DATE_DELTA)
+        .zip(BASELINE_TIMELINE_WIDTH)
+        .map(|(date, width)| {
+            let end = start + u16::from(*width);
+            let entry = (date, start, end);
+            start = end;
+            entry
         })
         .collect()
 });

--- a/data/src/blob.rs
+++ b/data/src/blob.rs
@@ -1,21 +1,28 @@
-//! Bundled byte arrays, stored either verbatim or deflated.
+//! Bundled byte arrays, stored either verbatim or run-length encoded, and either way
+//! optionally deflated.
 //!
-//! Without the `deflate` feature a blob is the bytes themselves and costs nothing at
-//! runtime; leaving the data uncompressed suits binaries that get packed as a whole
-//! afterwards. With the feature the bytes are a raw deflate stream that is inflated on
-//! first access and kept for the rest of the process.
+//! Without the `deflate` feature a verbatim blob is the bytes themselves and costs
+//! nothing at runtime; leaving the data uncompressed suits binaries that get packed as
+//! a whole afterwards. With the feature the bytes are a raw deflate stream that is
+//! inflated on first access and kept for the rest of the process.
 //!
 //! Deflate rather than a stronger codec because the decoder has to be paid for too.
 //! Measured against this data, zstd, brotli and xz each compress better but their
 //! decoders cost 5 to 8 times more code than miniz_oxide's inflate, and every one of
 //! them ends up larger overall.
+//!
+//! Run-length encoding is chosen per array by the generator, which takes it only where
+//! it shrinks the array by at least a third. Several of these columns are sorted, or
+//! are the high plane of an index that never reaches its second byte, and collapse to
+//! almost nothing; it costs a heap copy at load time, so arrays without real runs keep
+//! their verbatim form.
 
-#[cfg(feature = "deflate")]
 use std::sync::OnceLock;
 
 pub(crate) struct Blob {
     bytes: &'static [u8],
-    #[cfg(feature = "deflate")]
+    /// One count per byte of `bytes`, or empty when the array is stored verbatim.
+    counts: &'static [u8],
     cell: OnceLock<Vec<u8>>,
 }
 
@@ -23,20 +30,49 @@ impl Blob {
     pub(crate) const fn new(bytes: &'static [u8]) -> Self {
         Self {
             bytes,
-            #[cfg(feature = "deflate")]
+            counts: &[],
+            cell: OnceLock::new(),
+        }
+    }
+
+    pub(crate) const fn rle(values: &'static [u8], counts: &'static [u8]) -> Self {
+        Self {
+            bytes: values,
+            counts,
             cell: OnceLock::new(),
         }
     }
 
     #[cfg(not(feature = "deflate"))]
     pub(crate) fn get(&'static self) -> &'static [u8] {
-        self.bytes
+        if self.counts.is_empty() {
+            self.bytes
+        } else {
+            self.cell.get_or_init(|| unrle(self.bytes, self.counts))
+        }
     }
 
     #[cfg(feature = "deflate")]
     pub(crate) fn get(&'static self) -> &'static [u8] {
-        self.cell.get_or_init(|| inflate(self.bytes))
+        self.cell.get_or_init(|| {
+            let bytes = inflate(self.bytes);
+            if self.counts.is_empty() {
+                bytes
+            } else {
+                unrle(&bytes, &inflate(self.counts))
+            }
+        })
     }
+}
+
+/// Undoes the run-length encoding `write_blob` in generate-data applies: one run per
+/// value and count pair, with runs too long for a count byte split across several pairs.
+fn unrle(values: &[u8], counts: &[u8]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(counts.iter().map(|count| usize::from(*count)).sum());
+    for (value, count) in values.iter().zip(counts) {
+        bytes.extend(std::iter::repeat_n(*value, usize::from(*count)));
+    }
+    bytes
 }
 
 /// Inflates a blob written by `write_blob` in generate-data: the inflated length as a

--- a/data/src/blob.rs
+++ b/data/src/blob.rs
@@ -1,0 +1,71 @@
+//! Bundled byte arrays, stored either verbatim or deflated.
+//!
+//! Without the `deflate` feature a blob is the bytes themselves and costs nothing at
+//! runtime; leaving the data uncompressed suits binaries that get packed as a whole
+//! afterwards. With the feature the bytes are a raw deflate stream that is inflated on
+//! first access and kept for the rest of the process.
+//!
+//! Deflate rather than a stronger codec because the decoder has to be paid for too.
+//! Measured against this data, zstd, brotli and xz each compress better but their
+//! decoders cost 5 to 8 times more code than miniz_oxide's inflate, and every one of
+//! them ends up larger overall.
+
+#[cfg(feature = "deflate")]
+use std::sync::OnceLock;
+
+pub(crate) struct Blob {
+    bytes: &'static [u8],
+    #[cfg(feature = "deflate")]
+    cell: OnceLock<Vec<u8>>,
+}
+
+impl Blob {
+    pub(crate) const fn new(bytes: &'static [u8]) -> Self {
+        Self {
+            bytes,
+            #[cfg(feature = "deflate")]
+            cell: OnceLock::new(),
+        }
+    }
+
+    #[cfg(not(feature = "deflate"))]
+    pub(crate) fn get(&'static self) -> &'static [u8] {
+        self.bytes
+    }
+
+    #[cfg(feature = "deflate")]
+    pub(crate) fn get(&'static self) -> &'static [u8] {
+        self.cell.get_or_init(|| inflate(self.bytes))
+    }
+}
+
+/// Inflates a blob written by `write_blob` in generate-data: the inflated length as a
+/// little-endian `u32`, then a raw deflate stream. Knowing the length up front means a
+/// single pass into an exactly sized buffer, which keeps miniz_oxide's buffer-growing
+/// wrapper -- and the code size that comes with it -- out of the binary.
+#[cfg(feature = "deflate")]
+fn inflate(blob: &[u8]) -> Vec<u8> {
+    use miniz_oxide::inflate::{
+        TINFLStatus,
+        core::{
+            DecompressorOxide, decompress, inflate_flags::TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF,
+        },
+    };
+
+    let (len, compressed) = blob.split_at(4);
+    let len = u32::from_le_bytes([len[0], len[1], len[2], len[3]]) as usize;
+
+    let mut out = vec![0; len];
+    let (status, _, written) = decompress(
+        &mut DecompressorOxide::default(),
+        compressed,
+        &mut out,
+        0,
+        TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF,
+    );
+    assert!(
+        status == TINFLStatus::Done && written == len,
+        "failed to inflate bundled data"
+    );
+    out
+}

--- a/data/src/caniuse.rs
+++ b/data/src/caniuse.rs
@@ -22,11 +22,44 @@ pub struct VersionDetail {
 }
 
 include!("generated/caniuse-browsers.rs");
+include!("generated/caniuse-global-usage.rs");
 
-static CANIUSE_BROWSERS: BinMap<PooledStr, BrowserStat> = BinMap(BROWSERS_STATS);
+static VERSION_LIST: LazyLock<Vec<VersionDetail>> = LazyLock::new(|| {
+    (0..VERSION_LIST_VERSION.len())
+        .map(|index| VersionDetail {
+            version: VERSION_LIST_VERSION[index],
+            release_date: VERSION_LIST_RELEASE_DATE[index],
+            released: VERSION_LIST_RELEASED[index],
+            global_usage: VERSION_LIST_GLOBAL_USAGE[index],
+        })
+        .collect()
+});
 
-static CANIUSE_GLOBAL_USAGE: &[(PooledStr, PooledStr, f32)] =
-    include!("generated/caniuse-global-usage.rs");
+static BROWSERS_STATS: LazyLock<Vec<(PooledStr, BrowserStat)>> = LazyLock::new(|| {
+    (0..BROWSERS_STATS_KEY.len())
+        .map(|index| {
+            (
+                BROWSERS_STATS_KEY[index],
+                BrowserStat(BROWSERS_STATS_START[index], BROWSERS_STATS_END[index]),
+            )
+        })
+        .collect()
+});
+
+static CANIUSE_BROWSERS: LazyLock<BinMap<'static, PooledStr, BrowserStat>> =
+    LazyLock::new(|| BinMap(&BROWSERS_STATS));
+
+static CANIUSE_GLOBAL_USAGE: LazyLock<Vec<(PooledStr, PooledStr, f32)>> = LazyLock::new(|| {
+    (0..CANIUSE_GLOBAL_USAGE_BROWSER.len())
+        .map(|index| {
+            (
+                CANIUSE_GLOBAL_USAGE_BROWSER[index],
+                CANIUSE_GLOBAL_USAGE_VERSION[index],
+                CANIUSE_GLOBAL_USAGE_USAGE[index],
+            )
+        })
+        .collect()
+});
 
 static BROWSER_VERSION_ALIASES: LazyLock<
     AHashMap<&'static str, AHashMap<&'static str, &'static str>>,

--- a/data/src/caniuse.rs
+++ b/data/src/caniuse.rs
@@ -4,7 +4,18 @@ use std::{borrow::Cow, sync::LazyLock};
 pub mod features;
 pub mod region;
 
-use crate::utils::{BinMap, PooledStr};
+use crate::utils::{BinMap, PooledStr, undelta};
+
+/// Usage percentages are bundled as thousandths.
+fn per_mille(value: u16) -> f32 {
+    f32::from(value) / 1000.0
+}
+
+/// Region usage percentages are bundled as hundred-thousandths; see `per_100k` in
+/// generate-data for why they need the extra range.
+pub(crate) fn per_100k(value: u32) -> f32 {
+    value as f32 / 100_000.0
+}
 
 pub const ANDROID_EVERGREEN_FIRST: f32 = 37.0;
 pub const OP_MOB_BLINK_FIRST: u32 = 14;
@@ -25,23 +36,31 @@ include!("generated/caniuse-browsers.rs");
 include!("generated/caniuse-global-usage.rs");
 
 static VERSION_LIST: LazyLock<Vec<VersionDetail>> = LazyLock::new(|| {
-    (0..VERSION_LIST_VERSION.len())
-        .map(|index| VersionDetail {
-            version: VERSION_LIST_VERSION[index],
-            release_date: VERSION_LIST_RELEASE_DATE[index],
-            released: VERSION_LIST_RELEASED[index],
-            global_usage: VERSION_LIST_GLOBAL_USAGE[index],
-        })
+    undelta(VERSION_LIST_VERSION_DELTA)
+        .zip(undelta(VERSION_LIST_RELEASE_DATE_DELTA))
+        .zip(VERSION_LIST_RELEASED)
+        .zip(VERSION_LIST_GLOBAL_USAGE)
+        .map(
+            |(((version, release_date), released), usage)| VersionDetail {
+                version: PooledStr(version),
+                release_date: i64::from(release_date),
+                released: *released,
+                global_usage: per_mille(*usage),
+            },
+        )
         .collect()
 });
 
 static BROWSERS_STATS: LazyLock<Vec<(PooledStr, BrowserStat)>> = LazyLock::new(|| {
-    (0..BROWSERS_STATS_KEY.len())
-        .map(|index| {
-            (
-                BROWSERS_STATS_KEY[index],
-                BrowserStat(BROWSERS_STATS_START[index], BROWSERS_STATS_END[index]),
-            )
+    let mut start = 0;
+    BROWSERS_STATS_KEY
+        .iter()
+        .zip(BROWSERS_STATS_WIDTH)
+        .map(|(key, width)| {
+            let end = start + u32::from(*width);
+            let stat = BrowserStat(start, end);
+            start = end;
+            (*key, stat)
         })
         .collect()
 });
@@ -55,7 +74,7 @@ static CANIUSE_GLOBAL_USAGE: LazyLock<Vec<(PooledStr, PooledStr, f32)>> = LazyLo
             (
                 CANIUSE_GLOBAL_USAGE_BROWSER[index],
                 CANIUSE_GLOBAL_USAGE_VERSION[index],
-                CANIUSE_GLOBAL_USAGE_USAGE[index],
+                per_mille(CANIUSE_GLOBAL_USAGE_USAGE[index]),
             )
         })
         .collect()

--- a/data/src/caniuse.rs
+++ b/data/src/caniuse.rs
@@ -299,10 +299,24 @@ pub fn normalize_version<'a>(
     }
 }
 
+/// Looks up one browser by name, for the feature tables to resolve versions through.
+pub(crate) fn browser_stat(name: &str) -> Option<&'static BrowserStat> {
+    CANIUSE_BROWSERS.get(name)
+}
+
 impl BrowserStat {
     pub fn version_list(&self) -> &'static [VersionDetail] {
-        let range = (self.0 as usize)..(self.1 as usize);
-        &VERSION_LIST[range]
+        &VERSION_LIST[self.range()]
+    }
+
+    /// The version list permuted into lexicographic order, so that a feature lookup can
+    /// binary search it by version string.
+    pub(crate) fn lex_order(&self) -> &'static [u8] {
+        &VERSION_LIST_LEX_ORDER.get()[self.range()]
+    }
+
+    fn range(&self) -> std::ops::Range<usize> {
+        (self.0 as usize)..(self.1 as usize)
     }
 }
 

--- a/data/src/caniuse.rs
+++ b/data/src/caniuse.rs
@@ -17,6 +17,12 @@ pub(crate) fn per_100k(value: u32) -> f32 {
     value as f32 / 100_000.0
 }
 
+/// Version strings are interned into one table; every array that refers to a version
+/// holds a `u16` index into it, split across a low and a high byte array.
+pub(crate) fn version_in_table(index: u16) -> &'static str {
+    VERSION_TABLE[usize::from(index)].as_str()
+}
+
 pub const ANDROID_EVERGREEN_FIRST: f32 = 37.0;
 pub const OP_MOB_BLINK_FIRST: u32 = 14;
 

--- a/data/src/caniuse.rs
+++ b/data/src/caniuse.rs
@@ -4,7 +4,10 @@ use std::{borrow::Cow, sync::LazyLock};
 pub mod features;
 pub mod region;
 
-use crate::utils::{BinMap, PooledStr, undelta};
+use crate::{
+    blob::Blob,
+    utils::{BinMap, PooledStr, undelta},
+};
 
 /// Usage percentages are bundled as thousandths.
 fn per_mille(value: u16) -> f32 {
@@ -25,11 +28,12 @@ pub(crate) fn version_in_table(index: u16) -> &'static str {
 
 /// Reads a column of table indices back out of its low and high byte arrays.
 pub(crate) fn version_indices(
-    low: &'static [u8],
-    high: &'static [u8],
+    low: &'static Blob,
+    high: &'static Blob,
 ) -> impl Iterator<Item = u16> {
-    low.iter()
-        .zip(high)
+    low.get()
+        .iter()
+        .zip(high.get())
         .map(|(low, high)| u16::from_le_bytes([*low, *high]))
 }
 
@@ -53,7 +57,7 @@ include!("generated/caniuse-browsers.rs");
 include!("generated/caniuse-global-usage.rs");
 
 static VERSION_LIST: LazyLock<Vec<VersionDetail>> = LazyLock::new(|| {
-    version_indices(VERSION_LIST_VERSION_LO, VERSION_LIST_VERSION_HI)
+    version_indices(&VERSION_LIST_VERSION_LO, &VERSION_LIST_VERSION_HI)
         .zip(undelta(VERSION_LIST_RELEASE_DATE_DELTA))
         .zip(VERSION_LIST_RELEASED)
         .zip(VERSION_LIST_GLOBAL_USAGE)
@@ -88,10 +92,11 @@ static CANIUSE_BROWSERS: LazyLock<BinMap<'static, PooledStr, BrowserStat>> =
 static CANIUSE_GLOBAL_USAGE: LazyLock<Vec<(&'static str, &'static str, f32)>> =
     LazyLock::new(|| {
         CANIUSE_GLOBAL_USAGE_BROWSER
+            .get()
             .iter()
             .zip(version_indices(
-                CANIUSE_GLOBAL_USAGE_VERSION_LO,
-                CANIUSE_GLOBAL_USAGE_VERSION_HI,
+                &CANIUSE_GLOBAL_USAGE_VERSION_LO,
+                &CANIUSE_GLOBAL_USAGE_VERSION_HI,
             ))
             .zip(CANIUSE_GLOBAL_USAGE_USAGE)
             .map(|((browser, version), usage)| {

--- a/data/src/caniuse.rs
+++ b/data/src/caniuse.rs
@@ -23,6 +23,16 @@ pub(crate) fn version_in_table(index: u16) -> &'static str {
     VERSION_TABLE[usize::from(index)].as_str()
 }
 
+/// Reads a column of table indices back out of its low and high byte arrays.
+pub(crate) fn version_indices(
+    low: &'static [u8],
+    high: &'static [u8],
+) -> impl Iterator<Item = u16> {
+    low.iter()
+        .zip(high)
+        .map(|(low, high)| u16::from_le_bytes([*low, *high]))
+}
+
 pub const ANDROID_EVERGREEN_FIRST: f32 = 37.0;
 pub const OP_MOB_BLINK_FIRST: u32 = 14;
 
@@ -38,17 +48,18 @@ pub struct VersionDetail {
     pub global_usage: f32,
 }
 
+include!("generated/version-table.rs");
 include!("generated/caniuse-browsers.rs");
 include!("generated/caniuse-global-usage.rs");
 
 static VERSION_LIST: LazyLock<Vec<VersionDetail>> = LazyLock::new(|| {
-    undelta(VERSION_LIST_VERSION_DELTA)
+    version_indices(VERSION_LIST_VERSION_LO, VERSION_LIST_VERSION_HI)
         .zip(undelta(VERSION_LIST_RELEASE_DATE_DELTA))
         .zip(VERSION_LIST_RELEASED)
         .zip(VERSION_LIST_GLOBAL_USAGE)
         .map(
             |(((version, release_date), released), usage)| VersionDetail {
-                version: PooledStr(version),
+                version: VERSION_TABLE[usize::from(version)],
                 release_date: i64::from(release_date),
                 released: *released,
                 global_usage: per_mille(*usage),
@@ -74,17 +85,24 @@ static BROWSERS_STATS: LazyLock<Vec<(PooledStr, BrowserStat)>> = LazyLock::new(|
 static CANIUSE_BROWSERS: LazyLock<BinMap<'static, PooledStr, BrowserStat>> =
     LazyLock::new(|| BinMap(&BROWSERS_STATS));
 
-static CANIUSE_GLOBAL_USAGE: LazyLock<Vec<(PooledStr, PooledStr, f32)>> = LazyLock::new(|| {
-    (0..CANIUSE_GLOBAL_USAGE_BROWSER.len())
-        .map(|index| {
-            (
-                CANIUSE_GLOBAL_USAGE_BROWSER[index],
-                CANIUSE_GLOBAL_USAGE_VERSION[index],
-                per_mille(CANIUSE_GLOBAL_USAGE_USAGE[index]),
-            )
-        })
-        .collect()
-});
+static CANIUSE_GLOBAL_USAGE: LazyLock<Vec<(&'static str, &'static str, f32)>> =
+    LazyLock::new(|| {
+        CANIUSE_GLOBAL_USAGE_BROWSER
+            .iter()
+            .zip(version_indices(
+                CANIUSE_GLOBAL_USAGE_VERSION_LO,
+                CANIUSE_GLOBAL_USAGE_VERSION_HI,
+            ))
+            .zip(CANIUSE_GLOBAL_USAGE_USAGE)
+            .map(|((browser, version), usage)| {
+                (
+                    crate::decode_browser_name(*browser),
+                    version_in_table(version),
+                    per_mille(*usage),
+                )
+            })
+            .collect()
+    });
 
 static BROWSER_VERSION_ALIASES: LazyLock<
     AHashMap<&'static str, AHashMap<&'static str, &'static str>>,
@@ -217,10 +235,7 @@ pub fn iter_browser_stat(
 }
 
 pub fn iter_global_usage() -> impl ExactSizeIterator<Item = (&'static str, &'static str, f32)> {
-    CANIUSE_GLOBAL_USAGE
-        .iter()
-        .copied()
-        .map(|(name, version, usage)| (name.as_str(), version.as_str(), usage))
+    CANIUSE_GLOBAL_USAGE.iter().copied()
 }
 
 pub fn get_browser_version_alias(name: &str, version: &str) -> Option<&'static str> {

--- a/data/src/caniuse/features.rs
+++ b/data/src/caniuse/features.rs
@@ -1,8 +1,5 @@
 use super::PooledStr;
-use crate::{
-    decode_browser_name,
-    utils::{BinMap, U32},
-};
+use crate::{decode_browser_name, utils::BinMap};
 use std::sync::LazyLock;
 
 #[derive(Clone, Copy)]
@@ -16,9 +13,9 @@ pub struct VersionList(u32, u32);
 // static FEATURES_START: &[u32]; // browsers list start
 // static FEATURES_END: &[u32]; // browsers list end
 //
-// static FEATURES_STAT_VERSION_STORE: &[U32]; // version string
-// static FEATURES_STAT_VERSION_START: &[U32]; // version range start
-// static FEATURES_STAT_VERSION_END: &[U32]; // version range end
+// static FEATURES_STAT_VERSION_STORE: &[u32]; // version string
+// static FEATURES_STAT_VERSION_START: &[u32]; // version range start
+// static FEATURES_STAT_VERSION_END: &[u32]; // version range end
 //
 // static FEATURES_STAT_FLAGS: &[u8]; // support flag
 // static FEATURES_STAT_BROWSERS: &[u8]; // browser name id
@@ -40,8 +37,8 @@ static FEATURES_STAT_VERSION_INDEX: LazyLock<Vec<(u32, u32)>> = LazyLock::new(||
     (0..FEATURES_STAT_VERSION_START.len())
         .map(|index| {
             (
-                FEATURES_STAT_VERSION_START[index].get(),
-                FEATURES_STAT_VERSION_END[index].get(),
+                FEATURES_STAT_VERSION_START[index],
+                FEATURES_STAT_VERSION_END[index],
             )
         })
         .collect()
@@ -74,7 +71,7 @@ impl VersionList {
     pub fn get(&self, version: &str) -> Option<u8> {
         let range = (self.0 as usize)..(self.1 as usize);
         let index = FEATURES_STAT_VERSION_STORE[range.clone()]
-            .binary_search_by_key(&version, |s| PooledStr(s.get()).as_str())
+            .binary_search_by_key(&version, |s| PooledStr(*s).as_str())
             .ok()?;
         Some(FEATURES_STAT_FLAGS[range][index])
     }

--- a/data/src/caniuse/features.rs
+++ b/data/src/caniuse/features.rs
@@ -1,16 +1,23 @@
-use super::PooledStr;
+use super::{PooledStr, VersionDetail};
 use crate::{
     blob::Blob,
     decode_browser_name,
     utils::{BinMap, undelta},
 };
-use std::{cmp::Ordering, sync::LazyLock};
+use std::sync::LazyLock;
 
 #[derive(Clone, Copy)]
 pub struct Feature(u32, u32);
 
 #[derive(Clone, Copy)]
-pub struct VersionList(u32, u32);
+pub struct VersionList {
+    // The browser's own version list, in release order, paired with the permutation
+    // that puts it in lexicographic order.
+    versions: &'static [VersionDetail],
+    lex_order: &'static [u8],
+    // Index of this browser's first flag within FEATURES_STAT_FLAGS.
+    base: u32,
+}
 
 // ```rust
 // The ranges below tile their arrays end to end, so only widths are bundled and the
@@ -19,10 +26,7 @@ pub struct VersionList(u32, u32);
 // static FEATURES_KEY_DELTA: &[u32]; // feature name
 // static FEATURES_WIDTH: Blob; // browsers list width
 //
-// static FEATURES_STAT_VERSION_LO: Blob; // version, low byte of a VERSION_TABLE index
-// static FEATURES_STAT_VERSION_HI: Blob; // version, high byte
 // static FEATURES_STAT_VERSION_WIDTH: Blob; // version range width
-//
 // static FEATURES_STAT_FLAGS: Blob; // support flag, two bits each
 // static FEATURES_STAT_BROWSERS: Blob; // browser name id
 // ```
@@ -41,16 +45,15 @@ static FEATURES: LazyLock<Vec<(PooledStr, Feature)>> = LazyLock::new(|| {
         .collect()
 });
 
-static FEATURES_STAT_VERSION_INDEX: LazyLock<Vec<(u32, u32)>> = LazyLock::new(|| {
+static FEATURES_STAT_FLAG_START: LazyLock<Vec<u32>> = LazyLock::new(|| {
     let mut start = 0;
     FEATURES_STAT_VERSION_WIDTH
         .get()
         .iter()
         .map(|width| {
-            let end = start + u32::from(*width);
-            let range = (start, end);
-            start = end;
-            range
+            let base = start;
+            start += u32::from(*width);
+            base
         })
         .collect()
 });
@@ -59,52 +62,49 @@ pub fn get_feature_stat(name: &str) -> Option<Feature> {
     BinMap(&FEATURES).get(name).copied()
 }
 
+// caniuse states every feature for every version of a browser (checked by
+// generate-data), so a browser's flags line up with its version list position by
+// position and no versions are stored on the feature side at all.
+fn version_list_at(index: usize, browser: &str) -> VersionList {
+    let stat = super::browser_stat(browser).expect("feature refers to unknown browser");
+    VersionList {
+        versions: stat.version_list(),
+        lex_order: stat.lex_order(),
+        base: FEATURES_STAT_FLAG_START[index],
+    }
+}
+
 impl Feature {
     pub fn get(&self, browser: &str) -> Option<VersionList> {
         let range = (self.0 as usize)..(self.1 as usize);
         let index = FEATURES_STAT_BROWSERS.get()[range.clone()]
             .binary_search_by_key(&browser, |&k| decode_browser_name(k))
             .ok()?;
-        let list = FEATURES_STAT_VERSION_INDEX[range][index];
-        Some(VersionList(list.0, list.1))
+        Some(version_list_at(range.start + index, browser))
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&'static str, VersionList)> {
-        let range = (self.0 as usize)..(self.1 as usize);
-        FEATURES_STAT_BROWSERS.get()[range.clone()]
+        let start = self.0 as usize;
+        FEATURES_STAT_BROWSERS.get()[start..(self.1 as usize)]
             .iter()
-            .zip(&FEATURES_STAT_VERSION_INDEX[range])
-            .map(|(&name, &list)| (decode_browser_name(name), VersionList(list.0, list.1)))
+            .enumerate()
+            .map(move |(offset, &id)| {
+                let name = decode_browser_name(id);
+                (name, version_list_at(start + offset, name))
+            })
     }
-}
-
-/// The version at `index`, resolved through the shared table. Kept as a lookup rather
-/// than a materialized array so that neither the indices nor the strings are copied to
-/// the heap.
-fn version_at(index: usize) -> &'static str {
-    let table_index = u16::from_le_bytes([
-        FEATURES_STAT_VERSION_LO.get()[index],
-        FEATURES_STAT_VERSION_HI.get()[index],
-    ]);
-    super::version_in_table(table_index)
 }
 
 impl VersionList {
     pub fn get(&self, version: &str) -> Option<u8> {
-        // The range is ordered by version string, so it is binary searched by hand:
-        // the versions live behind an index and are not a slice to search over.
-        let (mut low, mut high) = (self.0 as usize, self.1 as usize);
-        while low < high {
-            let mid = low + (high - low) / 2;
-            match version_at(mid).cmp(version) {
-                Ordering::Less => low = mid + 1,
-                Ordering::Greater => high = mid,
-                // Two bits per flag.
-                Ordering::Equal => {
-                    return Some((FEATURES_STAT_FLAGS.get()[mid / 4] >> (2 * (mid % 4))) & 3);
-                }
-            }
-        }
-        None
+        let rank = self
+            .lex_order
+            .binary_search_by(|&position| {
+                self.versions[usize::from(position)].version().cmp(version)
+            })
+            .ok()?;
+        let index = self.base as usize + usize::from(self.lex_order[rank]);
+        // Two bits per flag.
+        Some((FEATURES_STAT_FLAGS.get()[index / 4] >> (2 * (index % 4))) & 3)
     }
 }

--- a/data/src/caniuse/features.rs
+++ b/data/src/caniuse/features.rs
@@ -3,7 +3,7 @@ use crate::{
     decode_browser_name,
     utils::{BinMap, undelta},
 };
-use std::sync::LazyLock;
+use std::{cmp::Ordering, sync::LazyLock};
 
 #[derive(Clone, Copy)]
 pub struct Feature(u32, u32);
@@ -18,7 +18,8 @@ pub struct VersionList(u32, u32);
 // static FEATURES_KEY_DELTA: &[u32]; // feature name
 // static FEATURES_WIDTH: &[u8]; // browsers list width
 //
-// static FEATURES_STAT_VERSION_STORE: &[u32]; // version string
+// static FEATURES_STAT_VERSION_LO: &[u8]; // version, low byte of a VERSION_TABLE index
+// static FEATURES_STAT_VERSION_HI: &[u8]; // version, high byte
 // static FEATURES_STAT_VERSION_WIDTH: &[u8]; // version range width
 //
 // static FEATURES_STAT_FLAGS: &[u8]; // support flag, two bits each
@@ -75,14 +76,33 @@ impl Feature {
     }
 }
 
+/// The version at `index`, resolved through the shared table. Kept as a lookup rather
+/// than a materialized array so that neither the indices nor the strings are copied to
+/// the heap.
+fn version_at(index: usize) -> &'static str {
+    let table_index = u16::from_le_bytes([
+        FEATURES_STAT_VERSION_LO[index],
+        FEATURES_STAT_VERSION_HI[index],
+    ]);
+    super::version_in_table(table_index)
+}
+
 impl VersionList {
     pub fn get(&self, version: &str) -> Option<u8> {
-        let range = (self.0 as usize)..(self.1 as usize);
-        let index = FEATURES_STAT_VERSION_STORE[range.clone()]
-            .binary_search_by_key(&version, |s| PooledStr(*s).as_str())
-            .ok()?;
-        // Two bits per flag.
-        let index = range.start + index;
-        Some((FEATURES_STAT_FLAGS[index / 4] >> (2 * (index % 4))) & 3)
+        // The range is ordered by version string, so it is binary searched by hand:
+        // the versions live behind an index and are not a slice to search over.
+        let (mut low, mut high) = (self.0 as usize, self.1 as usize);
+        while low < high {
+            let mid = low + (high - low) / 2;
+            match version_at(mid).cmp(version) {
+                Ordering::Less => low = mid + 1,
+                Ordering::Greater => high = mid,
+                // Two bits per flag.
+                Ordering::Equal => {
+                    return Some((FEATURES_STAT_FLAGS[mid / 4] >> (2 * (mid % 4))) & 3);
+                }
+            }
+        }
+        None
     }
 }

--- a/data/src/caniuse/features.rs
+++ b/data/src/caniuse/features.rs
@@ -1,5 +1,8 @@
 use super::PooledStr;
-use crate::{decode_browser_name, utils::BinMap};
+use crate::{
+    decode_browser_name,
+    utils::{BinMap, undelta},
+};
 use std::sync::LazyLock;
 
 #[derive(Clone, Copy)]
@@ -9,37 +12,42 @@ pub struct Feature(u32, u32);
 pub struct VersionList(u32, u32);
 
 // ```rust
-// static FEATURES_KEY: &[PooledStr]; // feature name
-// static FEATURES_START: &[u32]; // browsers list start
-// static FEATURES_END: &[u32]; // browsers list end
+// The ranges below tile their arrays end to end, so only widths are bundled and the
+// starts are a prefix sum, rebuilt on first use.
+//
+// static FEATURES_KEY_DELTA: &[u32]; // feature name
+// static FEATURES_WIDTH: &[u8]; // browsers list width
 //
 // static FEATURES_STAT_VERSION_STORE: &[u32]; // version string
-// static FEATURES_STAT_VERSION_START: &[u32]; // version range start
-// static FEATURES_STAT_VERSION_END: &[u32]; // version range end
+// static FEATURES_STAT_VERSION_WIDTH: &[u8]; // version range width
 //
-// static FEATURES_STAT_FLAGS: &[u8]; // support flag
+// static FEATURES_STAT_FLAGS: &[u8]; // support flag, two bits each
 // static FEATURES_STAT_BROWSERS: &[u8]; // browser name id
 // ```
 include!("../generated/caniuse-feature-matching.rs");
 
 static FEATURES: LazyLock<Vec<(PooledStr, Feature)>> = LazyLock::new(|| {
-    (0..FEATURES_KEY.len())
-        .map(|index| {
-            (
-                FEATURES_KEY[index],
-                Feature(FEATURES_START[index], FEATURES_END[index]),
-            )
+    let mut start = 0;
+    undelta(FEATURES_KEY_DELTA)
+        .zip(FEATURES_WIDTH)
+        .map(|(key, width)| {
+            let end = start + u32::from(*width);
+            let feature = Feature(start, end);
+            start = end;
+            (PooledStr(key), feature)
         })
         .collect()
 });
 
 static FEATURES_STAT_VERSION_INDEX: LazyLock<Vec<(u32, u32)>> = LazyLock::new(|| {
-    (0..FEATURES_STAT_VERSION_START.len())
-        .map(|index| {
-            (
-                FEATURES_STAT_VERSION_START[index],
-                FEATURES_STAT_VERSION_END[index],
-            )
+    let mut start = 0;
+    FEATURES_STAT_VERSION_WIDTH
+        .iter()
+        .map(|width| {
+            let end = start + u32::from(*width);
+            let range = (start, end);
+            start = end;
+            range
         })
         .collect()
 });
@@ -73,6 +81,8 @@ impl VersionList {
         let index = FEATURES_STAT_VERSION_STORE[range.clone()]
             .binary_search_by_key(&version, |s| PooledStr(*s).as_str())
             .ok()?;
-        Some(FEATURES_STAT_FLAGS[range][index])
+        // Two bits per flag.
+        let index = range.start + index;
+        Some((FEATURES_STAT_FLAGS[index / 4] >> (2 * (index % 4))) & 3)
     }
 }

--- a/data/src/caniuse/features.rs
+++ b/data/src/caniuse/features.rs
@@ -1,5 +1,6 @@
 use super::PooledStr;
 use crate::{
+    blob::Blob,
     decode_browser_name,
     utils::{BinMap, undelta},
 };
@@ -16,21 +17,21 @@ pub struct VersionList(u32, u32);
 // starts are a prefix sum, rebuilt on first use.
 //
 // static FEATURES_KEY_DELTA: &[u32]; // feature name
-// static FEATURES_WIDTH: &[u8]; // browsers list width
+// static FEATURES_WIDTH: Blob; // browsers list width
 //
-// static FEATURES_STAT_VERSION_LO: &[u8]; // version, low byte of a VERSION_TABLE index
-// static FEATURES_STAT_VERSION_HI: &[u8]; // version, high byte
-// static FEATURES_STAT_VERSION_WIDTH: &[u8]; // version range width
+// static FEATURES_STAT_VERSION_LO: Blob; // version, low byte of a VERSION_TABLE index
+// static FEATURES_STAT_VERSION_HI: Blob; // version, high byte
+// static FEATURES_STAT_VERSION_WIDTH: Blob; // version range width
 //
-// static FEATURES_STAT_FLAGS: &[u8]; // support flag, two bits each
-// static FEATURES_STAT_BROWSERS: &[u8]; // browser name id
+// static FEATURES_STAT_FLAGS: Blob; // support flag, two bits each
+// static FEATURES_STAT_BROWSERS: Blob; // browser name id
 // ```
 include!("../generated/caniuse-feature-matching.rs");
 
 static FEATURES: LazyLock<Vec<(PooledStr, Feature)>> = LazyLock::new(|| {
     let mut start = 0;
     undelta(FEATURES_KEY_DELTA)
-        .zip(FEATURES_WIDTH)
+        .zip(FEATURES_WIDTH.get())
         .map(|(key, width)| {
             let end = start + u32::from(*width);
             let feature = Feature(start, end);
@@ -43,6 +44,7 @@ static FEATURES: LazyLock<Vec<(PooledStr, Feature)>> = LazyLock::new(|| {
 static FEATURES_STAT_VERSION_INDEX: LazyLock<Vec<(u32, u32)>> = LazyLock::new(|| {
     let mut start = 0;
     FEATURES_STAT_VERSION_WIDTH
+        .get()
         .iter()
         .map(|width| {
             let end = start + u32::from(*width);
@@ -60,7 +62,7 @@ pub fn get_feature_stat(name: &str) -> Option<Feature> {
 impl Feature {
     pub fn get(&self, browser: &str) -> Option<VersionList> {
         let range = (self.0 as usize)..(self.1 as usize);
-        let index = FEATURES_STAT_BROWSERS[range.clone()]
+        let index = FEATURES_STAT_BROWSERS.get()[range.clone()]
             .binary_search_by_key(&browser, |&k| decode_browser_name(k))
             .ok()?;
         let list = FEATURES_STAT_VERSION_INDEX[range][index];
@@ -69,7 +71,7 @@ impl Feature {
 
     pub fn iter(&self) -> impl Iterator<Item = (&'static str, VersionList)> {
         let range = (self.0 as usize)..(self.1 as usize);
-        FEATURES_STAT_BROWSERS[range.clone()]
+        FEATURES_STAT_BROWSERS.get()[range.clone()]
             .iter()
             .zip(&FEATURES_STAT_VERSION_INDEX[range])
             .map(|(&name, &list)| (decode_browser_name(name), VersionList(list.0, list.1)))
@@ -81,8 +83,8 @@ impl Feature {
 /// the heap.
 fn version_at(index: usize) -> &'static str {
     let table_index = u16::from_le_bytes([
-        FEATURES_STAT_VERSION_LO[index],
-        FEATURES_STAT_VERSION_HI[index],
+        FEATURES_STAT_VERSION_LO.get()[index],
+        FEATURES_STAT_VERSION_HI.get()[index],
     ]);
     super::version_in_table(table_index)
 }
@@ -99,7 +101,7 @@ impl VersionList {
                 Ordering::Greater => high = mid,
                 // Two bits per flag.
                 Ordering::Equal => {
-                    return Some((FEATURES_STAT_FLAGS[mid / 4] >> (2 * (mid % 4))) & 3);
+                    return Some((FEATURES_STAT_FLAGS.get()[mid / 4] >> (2 * (mid % 4))) & 3);
                 }
             }
         }

--- a/data/src/caniuse/features.rs
+++ b/data/src/caniuse/features.rs
@@ -1,28 +1,54 @@
 use super::PooledStr;
 use crate::{
     decode_browser_name,
-    utils::{BinMap, PairU32, U32},
+    utils::{BinMap, U32},
 };
+use std::sync::LazyLock;
 
 #[derive(Clone, Copy)]
 pub struct Feature(u32, u32);
 
 #[derive(Clone, Copy)]
-pub struct VersionList(PairU32);
+pub struct VersionList(u32, u32);
 
 // ```rust
-// static FEATURES: &[(PooledStr, Feature)]; // feature name and browsers list
+// static FEATURES_KEY: &[PooledStr]; // feature name
+// static FEATURES_START: &[u32]; // browsers list start
+// static FEATURES_END: &[u32]; // browsers list end
 //
 // static FEATURES_STAT_VERSION_STORE: &[U32]; // version string
-// static FEATURES_STAT_VERSION_INDEX: &[PairU32]; // version range
+// static FEATURES_STAT_VERSION_START: &[U32]; // version range start
+// static FEATURES_STAT_VERSION_END: &[U32]; // version range end
 //
 // static FEATURES_STAT_FLAGS: &[u8]; // support flag
 // static FEATURES_STAT_BROWSERS: &[u8]; // browser name id
 // ```
 include!("../generated/caniuse-feature-matching.rs");
 
+static FEATURES: LazyLock<Vec<(PooledStr, Feature)>> = LazyLock::new(|| {
+    (0..FEATURES_KEY.len())
+        .map(|index| {
+            (
+                FEATURES_KEY[index],
+                Feature(FEATURES_START[index], FEATURES_END[index]),
+            )
+        })
+        .collect()
+});
+
+static FEATURES_STAT_VERSION_INDEX: LazyLock<Vec<(u32, u32)>> = LazyLock::new(|| {
+    (0..FEATURES_STAT_VERSION_START.len())
+        .map(|index| {
+            (
+                FEATURES_STAT_VERSION_START[index].get(),
+                FEATURES_STAT_VERSION_END[index].get(),
+            )
+        })
+        .collect()
+});
+
 pub fn get_feature_stat(name: &str) -> Option<Feature> {
-    BinMap(FEATURES).get(name).copied()
+    BinMap(&FEATURES).get(name).copied()
 }
 
 impl Feature {
@@ -32,7 +58,7 @@ impl Feature {
             .binary_search_by_key(&browser, |&k| decode_browser_name(k))
             .ok()?;
         let list = FEATURES_STAT_VERSION_INDEX[range][index];
-        Some(VersionList(list))
+        Some(VersionList(list.0, list.1))
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&'static str, VersionList)> {
@@ -40,13 +66,13 @@ impl Feature {
         FEATURES_STAT_BROWSERS[range.clone()]
             .iter()
             .zip(&FEATURES_STAT_VERSION_INDEX[range])
-            .map(|(&name, &list)| (decode_browser_name(name), VersionList(list)))
+            .map(|(&name, &list)| (decode_browser_name(name), VersionList(list.0, list.1)))
     }
 }
 
 impl VersionList {
     pub fn get(&self, version: &str) -> Option<u8> {
-        let range = (self.0.0.get() as usize)..(self.0.1.get() as usize);
+        let range = (self.0 as usize)..(self.1 as usize);
         let index = FEATURES_STAT_VERSION_STORE[range.clone()]
             .binary_search_by_key(&version, |s| PooledStr(s.get()).as_str())
             .ok()?;

--- a/data/src/caniuse/region.rs
+++ b/data/src/caniuse/region.rs
@@ -1,5 +1,6 @@
 use super::PooledStr;
 use crate::{
+    blob::Blob,
     decode_browser_name,
     utils::{BinMap, undelta},
 };
@@ -15,10 +16,10 @@ pub struct RegionData(u32, u32);
 // static REGIONS_KEY_DELTA: &[u32]; // region name
 // static REGIONS_WIDTH: &[u16]; // region data width
 //
-// static REGIONS_BROWSERS: &[u8]; // browser name id
-// static REGIONS_VERSION_LO: &[u8]; // version, low byte of a VERSION_TABLE index
-// static REGIONS_VERSION_HI: &[u8]; // version, high byte
-// static REGIONS_USAGES: &[u32]; // browser usage, in hundred-thousandths of a percent
+// static REGIONS_BROWSERS: Blob; // browser name id
+// static REGIONS_VERSION_LO: Blob; // version, low byte of a VERSION_TABLE index
+// static REGIONS_VERSION_HI: Blob; // version, high byte
+// static REGIONS_USAGE_0..3: Blob; // usage in hundred-thousandths, one byte plane each
 // ```
 include!("../generated/caniuse-region-matching.rs");
 
@@ -35,6 +36,16 @@ static REGIONS: LazyLock<Vec<(PooledStr, RegionData)>> = LazyLock::new(|| {
         .collect()
 });
 
+/// One usage figure, reassembled from the four byte planes it is stored in.
+fn usage_at(index: usize) -> u32 {
+    u32::from_le_bytes([
+        REGIONS_USAGE_0.get()[index],
+        REGIONS_USAGE_1.get()[index],
+        REGIONS_USAGE_2.get()[index],
+        REGIONS_USAGE_3.get()[index],
+    ])
+}
+
 pub fn get_usage_by_region(region: &str) -> Option<RegionData> {
     BinMap(&REGIONS).get(region).copied()
 }
@@ -43,16 +54,16 @@ impl RegionData {
     pub fn iter(&self) -> impl Iterator<Item = (&'static str, &'static str, f32)> {
         let range = (self.0 as usize)..(self.1 as usize);
 
-        REGIONS_BROWSERS[range.clone()]
+        REGIONS_BROWSERS.get()[range.clone()]
             .iter()
-            .zip(&REGIONS_VERSION_LO[range.clone()])
-            .zip(&REGIONS_VERSION_HI[range.clone()])
-            .zip(&REGIONS_USAGES[range])
-            .map(|(((browser, low), high), usage)| {
+            .zip(&REGIONS_VERSION_LO.get()[range.clone()])
+            .zip(&REGIONS_VERSION_HI.get()[range.clone()])
+            .zip(range.clone())
+            .map(|(((browser, low), high), index)| {
                 (
                     decode_browser_name(*browser),
                     super::version_in_table(u16::from_le_bytes([*low, *high])),
-                    super::per_100k(*usage),
+                    super::per_100k(usage_at(index)),
                 )
             })
     }

--- a/data/src/caniuse/region.rs
+++ b/data/src/caniuse/region.rs
@@ -3,12 +3,15 @@ use crate::{
     decode_browser_name,
     utils::{BinMap, U32},
 };
+use std::sync::LazyLock;
 
 #[derive(Clone, Copy)]
 pub struct RegionData(u32, u32);
 
 // ```rust
-// static REGIONS: &[(PooledStr, RegionData)]; // region name and region data
+// static REGIONS_KEY: &[PooledStr]; // region name
+// static REGIONS_START: &[u32]; // region data start
+// static REGIONS_END: &[u32]; // region data end
 //
 // static REGIONS_BROWSERS: &[u8]; // browser name id
 // static REGIONS_VERSIONS: &[U32]; // version string
@@ -16,8 +19,19 @@ pub struct RegionData(u32, u32);
 // ```
 include!("../generated/caniuse-region-matching.rs");
 
+static REGIONS: LazyLock<Vec<(PooledStr, RegionData)>> = LazyLock::new(|| {
+    (0..REGIONS_KEY.len())
+        .map(|index| {
+            (
+                REGIONS_KEY[index],
+                RegionData(REGIONS_START[index], REGIONS_END[index]),
+            )
+        })
+        .collect()
+});
+
 pub fn get_usage_by_region(region: &str) -> Option<RegionData> {
-    BinMap(REGIONS).get(region).copied()
+    BinMap(&REGIONS).get(region).copied()
 }
 
 impl RegionData {

--- a/data/src/caniuse/region.rs
+++ b/data/src/caniuse/region.rs
@@ -1,8 +1,5 @@
 use super::PooledStr;
-use crate::{
-    decode_browser_name,
-    utils::{BinMap, U32},
-};
+use crate::{decode_browser_name, utils::BinMap};
 use std::sync::LazyLock;
 
 #[derive(Clone, Copy)]
@@ -14,8 +11,8 @@ pub struct RegionData(u32, u32);
 // static REGIONS_END: &[u32]; // region data end
 //
 // static REGIONS_BROWSERS: &[u8]; // browser name id
-// static REGIONS_VERSIONS: &[U32]; // version string
-// static REGIONS_USAGES: &[U32]; // browser usage (f32)
+// static REGIONS_VERSIONS: &[u32]; // version string
+// static REGIONS_USAGES: &[u32]; // browser usage (f32 bits)
 // ```
 include!("../generated/caniuse-region-matching.rs");
 
@@ -45,8 +42,8 @@ impl RegionData {
             .map(|((browser, version), usage)| {
                 (
                     decode_browser_name(*browser),
-                    PooledStr(version.get()).as_str(),
-                    f32::from_bits(usage.get()),
+                    PooledStr(*version).as_str(),
+                    f32::from_bits(*usage),
                 )
             })
     }

--- a/data/src/caniuse/region.rs
+++ b/data/src/caniuse/region.rs
@@ -1,28 +1,35 @@
 use super::PooledStr;
-use crate::{decode_browser_name, utils::BinMap};
+use crate::{
+    decode_browser_name,
+    utils::{BinMap, undelta},
+};
 use std::sync::LazyLock;
 
 #[derive(Clone, Copy)]
 pub struct RegionData(u32, u32);
 
 // ```rust
-// static REGIONS_KEY: &[PooledStr]; // region name
-// static REGIONS_START: &[u32]; // region data start
-// static REGIONS_END: &[u32]; // region data end
+// The regions tile the data arrays end to end, so only widths are bundled and the
+// starts are a prefix sum, rebuilt on first use.
+//
+// static REGIONS_KEY_DELTA: &[u32]; // region name
+// static REGIONS_WIDTH: &[u16]; // region data width
 //
 // static REGIONS_BROWSERS: &[u8]; // browser name id
 // static REGIONS_VERSIONS: &[u32]; // version string
-// static REGIONS_USAGES: &[u32]; // browser usage (f32 bits)
+// static REGIONS_USAGES: &[u32]; // browser usage, in hundred-thousandths of a percent
 // ```
 include!("../generated/caniuse-region-matching.rs");
 
 static REGIONS: LazyLock<Vec<(PooledStr, RegionData)>> = LazyLock::new(|| {
-    (0..REGIONS_KEY.len())
-        .map(|index| {
-            (
-                REGIONS_KEY[index],
-                RegionData(REGIONS_START[index], REGIONS_END[index]),
-            )
+    let mut start = 0;
+    undelta(REGIONS_KEY_DELTA)
+        .zip(REGIONS_WIDTH)
+        .map(|(key, width)| {
+            let end = start + u32::from(*width);
+            let region = RegionData(start, end);
+            start = end;
+            (PooledStr(key), region)
         })
         .collect()
 });
@@ -43,7 +50,7 @@ impl RegionData {
                 (
                     decode_browser_name(*browser),
                     PooledStr(*version).as_str(),
-                    f32::from_bits(*usage),
+                    super::per_100k(*usage),
                 )
             })
     }

--- a/data/src/caniuse/region.rs
+++ b/data/src/caniuse/region.rs
@@ -16,7 +16,8 @@ pub struct RegionData(u32, u32);
 // static REGIONS_WIDTH: &[u16]; // region data width
 //
 // static REGIONS_BROWSERS: &[u8]; // browser name id
-// static REGIONS_VERSIONS: &[u32]; // version string
+// static REGIONS_VERSION_LO: &[u8]; // version, low byte of a VERSION_TABLE index
+// static REGIONS_VERSION_HI: &[u8]; // version, high byte
 // static REGIONS_USAGES: &[u32]; // browser usage, in hundred-thousandths of a percent
 // ```
 include!("../generated/caniuse-region-matching.rs");
@@ -44,12 +45,13 @@ impl RegionData {
 
         REGIONS_BROWSERS[range.clone()]
             .iter()
-            .zip(&REGIONS_VERSIONS[range.clone()])
+            .zip(&REGIONS_VERSION_LO[range.clone()])
+            .zip(&REGIONS_VERSION_HI[range.clone()])
             .zip(&REGIONS_USAGES[range])
-            .map(|((browser, version), usage)| {
+            .map(|(((browser, low), high), usage)| {
                 (
                     decode_browser_name(*browser),
-                    PooledStr(*version).as_str(),
+                    super::version_in_table(u16::from_le_bytes([*low, *high])),
                     super::per_100k(*usage),
                 )
             })

--- a/data/src/electron.rs
+++ b/data/src/electron.rs
@@ -1,6 +1,19 @@
-use std::ops::Range;
+use std::{ops::Range, sync::LazyLock};
 
 include!("generated/electron-to-chromium.rs");
+
+// Electron versions are bundled as hundredths, which represents every released
+// version exactly.
+static ELECTRON_VERSIONS: LazyLock<Vec<f32>> = LazyLock::new(|| {
+    let mut hundredths = 0u16;
+    ELECTRON_VERSION_STEP
+        .iter()
+        .map(|step| {
+            hundredths += u16::from(*step);
+            f32::from(hundredths) / 100.0
+        })
+        .collect()
+});
 
 pub fn versions() -> impl ExactSizeIterator<Item = (f32, &'static str)> + DoubleEndedIterator {
     ELECTRON_VERSIONS

--- a/data/src/lib.rs
+++ b/data/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod baseline;
+mod blob;
 pub mod caniuse;
 pub mod electron;
 pub mod node;

--- a/data/src/node.rs
+++ b/data/src/node.rs
@@ -1,7 +1,14 @@
 use chrono::NaiveDate;
+use std::sync::LazyLock;
 
 include!("generated/node-versions.rs");
 include!("generated/node-release-schedule.rs");
+
+static NODE_RELEASE_SCHEDULE: LazyLock<Vec<(NaiveDate, NaiveDate)>> = LazyLock::new(|| {
+    (0..NODE_RELEASE_START.len())
+        .map(|index| (NODE_RELEASE_START[index], NODE_RELEASE_END[index]))
+        .collect()
+});
 
 pub fn versions() -> &'static [&'static str] {
     NODE_VERSIONS

--- a/data/src/utils.rs
+++ b/data/src/utils.rs
@@ -29,16 +29,6 @@ impl<K, V> BinMap<'_, K, V> {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-#[repr(C)]
-pub(super) struct U32(u32);
-
-impl U32 {
-    pub const fn get(self) -> u32 {
-        self.0.to_le()
-    }
-}
-
 #[derive(Clone, Copy)]
 pub(super) struct PooledStr(pub(super) u32);
 

--- a/data/src/utils.rs
+++ b/data/src/utils.rs
@@ -29,11 +29,6 @@ impl<K, V> BinMap<'_, K, V> {
     }
 }
 
-// We define repr C instead of using tuple to ensure a stable memory layout.
-#[derive(Clone, Copy, Debug)]
-#[repr(C)]
-pub(super) struct PairU32(pub U32, pub U32);
-
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub(super) struct U32(u32);

--- a/data/src/utils.rs
+++ b/data/src/utils.rs
@@ -29,6 +29,16 @@ impl<K, V> BinMap<'_, K, V> {
     }
 }
 
+/// Undoes the zigzag delta the generator applies to arrays whose values drift by a
+/// little; see `zigzag_delta` there.
+pub(super) fn undelta(deltas: &'static [u32]) -> impl Iterator<Item = u32> {
+    let mut value = 0i64;
+    deltas.iter().map(move |delta| {
+        value += i64::from(*delta >> 1) ^ -i64::from(*delta & 1);
+        value as u32
+    })
+}
+
 #[derive(Clone, Copy)]
 pub(super) struct PooledStr(pub(super) u32);
 

--- a/generate-data/Cargo.toml
+++ b/generate-data/Cargo.toml
@@ -12,3 +12,5 @@ quote = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4" }
+miniz_oxide = "0.9.1"
+proc-macro2 = "1.0.107"

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -105,9 +105,19 @@ fn build_electron_to_chromium() -> Result<()> {
     .collect::<Vec<_>>();
     data.sort_by(|(a, _), (b, _)| a.total_cmp(b));
     let (electron_versions, chromium_versions): (Vec<_>, Vec<_>) = data.into_iter().unzip();
+    let mut previous = 0;
+    let electron_steps = electron_versions
+        .into_iter()
+        .map(|version| {
+            let hundredths = hundredths(version)?;
+            let step = u8::try_from(hundredths - previous)?;
+            previous = hundredths;
+            Ok(step)
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     let code = quote! {
-        static ELECTRON_VERSIONS: &[f32] = &[ #(#electron_versions),* ];
+        static ELECTRON_VERSION_STEP: &[u8] = &[ #(#electron_steps),* ];
         static CHROMIUM_VERSIONS: &[&str] = &[ #(#chromium_versions),* ];
     };
 
@@ -218,33 +228,36 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
 
             for version in &agent.version_list {
                 let version_str_id = strpool.insert(&version.version);
-                versions.push(quote! { PooledStr(#version_str_id) });
-                release_dates.push(version.release_date.unwrap_or_default());
+                versions.push(version_str_id);
+                release_dates.push(u32::try_from(version.release_date.unwrap_or_default())?);
                 released_flags.push(version.release_date.is_some());
-                usages.push(version.global_usage);
+                usages.push(per_mille(version.global_usage)?);
             }
 
             let end: u32 = versions.len().try_into().unwrap();
             stats.push((name_str_id, start, end));
         }
 
+        let versions = zigzag_delta(versions.into_iter());
+        let release_dates = zigzag_delta(release_dates.into_iter());
+
         stats.sort_by_key(|(name_str_id, ..)| strpool.get(*name_str_id));
         let stat_keys = stats
             .iter()
             .map(|(name_str_id, ..)| quote! { PooledStr(#name_str_id) });
-        let stat_starts = stats.iter().map(|(_, start, _)| start);
-        let stat_ends = stats.iter().map(|(.., end)| end);
+        // The ranges are contiguous, so only their widths are stored; the starts are
+        // rebuilt by prefix sum on first use.
+        let stat_widths = contiguous_widths_u8(stats.iter().map(|(_, start, end)| (*start, *end)))?;
 
         fs::write(
             format!("{OUT_DIR}/caniuse-browsers.rs"),
             quote! {
-                static VERSION_LIST_VERSION: &[PooledStr] = &[#(#versions),*];
-                static VERSION_LIST_RELEASE_DATE: &[i64] = &[#(#release_dates),*];
+                static VERSION_LIST_VERSION_DELTA: &[u32] = &[#(#versions),*];
+                static VERSION_LIST_RELEASE_DATE_DELTA: &[u32] = &[#(#release_dates),*];
                 static VERSION_LIST_RELEASED: &[bool] = &[#(#released_flags),*];
-                static VERSION_LIST_GLOBAL_USAGE: &[f32] = &[#(#usages),*];
+                static VERSION_LIST_GLOBAL_USAGE: &[u16] = &[#(#usages),*];
                 static BROWSERS_STATS_KEY: &[PooledStr] = &[#(#stat_keys),*];
-                static BROWSERS_STATS_START: &[u32] = &[#(#stat_starts),*];
-                static BROWSERS_STATS_END: &[u32] = &[#(#stat_ends),*];
+                static BROWSERS_STATS_WIDTH: &[u8] = &[#(#stat_widths),*];
             }
             .to_string(),
         )?;
@@ -268,13 +281,16 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         let versions = global_usage
             .iter()
             .map(|(_, version_str_id, _)| quote! { PooledStr(#version_str_id) });
-        let usages = global_usage.iter().map(|(.., usage)| usage);
+        let usages = global_usage
+            .iter()
+            .map(|(.., usage)| per_mille(**usage))
+            .collect::<Result<Vec<_>>>()?;
         fs::write(
             format!("{OUT_DIR}/caniuse-global-usage.rs"),
             quote! {
                 static CANIUSE_GLOBAL_USAGE_BROWSER: &[PooledStr] = &[#(#browsers),*];
                 static CANIUSE_GLOBAL_USAGE_VERSION: &[PooledStr] = &[#(#versions),*];
-                static CANIUSE_GLOBAL_USAGE_USAGE: &[f32] = &[#(#usages),*];
+                static CANIUSE_GLOBAL_USAGE_USAGE: &[u16] = &[#(#usages),*];
             }
             .to_string(),
         )?;
@@ -330,19 +346,33 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
             .iter()
             .map(|(browser, ..)| encode_browser_name(browser))
             .collect::<Vec<_>>();
-        let feature_keys = features
-            .iter()
-            .map(|(name_str_id, ..)| quote! { PooledStr(#name_str_id) });
-        let feature_starts = features.iter().map(|(_, start, _)| *start as u32);
-        let feature_ends = features.iter().map(|(.., end)| *end as u32);
+        let feature_keys = zigzag_delta(features.iter().map(|(name_str_id, ..)| *name_str_id));
+        let feature_widths = contiguous_widths_u8(
+            features
+                .iter()
+                .map(|(_, start, end)| (*start as u32, *end as u32)),
+        )?;
 
         let version_store = versions.iter();
-        let version_starts = stats.iter().map(|(_, start, _)| *start as u32);
-        let version_ends = stats.iter().map(|(.., end)| *end as u32);
+        let version_widths = contiguous_widths_u8(
+            stats
+                .iter()
+                .map(|(_, start, end)| (*start as u32, *end as u32)),
+        )?;
 
+        // Two bits per flag; only `y` and `a` are recorded.
+        let packed_flags = flags
+            .chunks(4)
+            .map(|chunk| {
+                chunk
+                    .iter()
+                    .enumerate()
+                    .fold(0u8, |byte, (i, flag)| byte | (flag << (2 * i)))
+            })
+            .collect::<Vec<_>>();
         fs::write(
             format!("{OUT_DIR}/caniuse-feature-flags.bin"),
-            flags.as_slice(),
+            packed_flags.as_slice(),
         )?;
         fs::write(
             format!("{OUT_DIR}/caniuse-feature-browsers.bin"),
@@ -352,13 +382,11 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         fs::write(
             format!("{OUT_DIR}/caniuse-feature-matching.rs"),
             quote! {
-                static FEATURES_KEY: &[PooledStr] = &[#(#feature_keys),*];
-                static FEATURES_START: &[u32] = &[#(#feature_starts),*];
-                static FEATURES_END: &[u32] = &[#(#feature_ends),*];
+                static FEATURES_KEY_DELTA: &[u32] = &[#(#feature_keys),*];
+                static FEATURES_WIDTH: &[u8] = &[#(#feature_widths),*];
 
                 static FEATURES_STAT_VERSION_STORE: &[u32] = &[#(#version_store),*];
-                static FEATURES_STAT_VERSION_START: &[u32] = &[#(#version_starts),*];
-                static FEATURES_STAT_VERSION_END: &[u32] = &[#(#version_ends),*];
+                static FEATURES_STAT_VERSION_WIDTH: &[u8] = &[#(#version_widths),*];
 
                 static FEATURES_STAT_FLAGS: &[u8] = include_bytes!("caniuse-feature-flags.bin");
                 static FEATURES_STAT_BROWSERS: &[u8] = include_bytes!("caniuse-feature-browsers.bin");
@@ -387,7 +415,10 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
                 }
             }
             let end = usages.len();
-            usages[start..end].sort_by(|(_, _, a), (_, _, b)| b.total_cmp(a));
+            // Canonical order, identical in every region, so the browser and version
+            // columns repeat and compress; `cover_by_region` re-sorts by usage, which is
+            // the only query that depends on the order.
+            usages[start..end].sort_by_key(|(browser, version, _)| (*browser, *version));
 
             let region_str_id = strpool.insert(region_name);
             region_usages.push((region_str_id, start, end));
@@ -400,20 +431,30 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         drop(browsers);
 
         let region_versions = usages.iter().map(|(_, v, _)| v);
-        let region_percents = usages.iter().map(|(.., usage)| usage.to_bits());
-
-        let region_keys = region_usages
+        let region_percents = usages
             .iter()
-            .map(|(region_str_id, ..)| quote! { PooledStr(#region_str_id) });
-        let region_starts = region_usages.iter().map(|(_, start, _)| *start as u32);
-        let region_ends = region_usages.iter().map(|(.., end)| *end as u32);
+            .map(|(.., usage)| per_100k(*usage))
+            .collect::<Result<Vec<_>>>()?;
+
+        let region_keys = zigzag_delta(
+            region_usages
+                .iter()
+                .map(|(region_str_id, ..)| *region_str_id),
+        );
+        let region_widths = contiguous_widths(
+            region_usages
+                .iter()
+                .map(|(_, start, end)| (*start as u32, *end as u32)),
+        )?
+        .into_iter()
+        .map(|width| Ok(u16::try_from(width)?))
+        .collect::<Result<Vec<_>>>()?;
 
         fs::write(
             format!("{OUT_DIR}/caniuse-region-matching.rs"),
             quote! {
-                static REGIONS_KEY: &[PooledStr] = &[#(#region_keys),*];
-                static REGIONS_START: &[u32] = &[#(#region_starts),*];
-                static REGIONS_END: &[u32] = &[#(#region_ends),*];
+                static REGIONS_KEY_DELTA: &[u32] = &[#(#region_keys),*];
+                static REGIONS_WIDTH: &[u16] = &[#(#region_widths),*];
 
                 static REGIONS_BROWSERS: &[u8] = include_bytes!("caniuse-region-browsers.bin");
                 static REGIONS_VERSIONS: &[u32] = &[#(#region_versions),*];
@@ -576,18 +617,20 @@ process.stdout.write(JSON.stringify(timeline));
         .iter()
         .map(|(_, version)| quote! { PooledStr(#version) });
     let version_browser_tokens = version_entries.iter().map(|(browser, _)| browser);
-    let timeline_dates = timeline_entries.iter().map(|(date, ..)| date);
-    let timeline_starts = timeline_entries.iter().map(|(_, start, _)| start);
-    let timeline_ends = timeline_entries.iter().map(|(.., end)| end);
+    let timeline_dates = zigzag_delta(timeline_entries.iter().map(|(date, ..)| *date));
+    let timeline_widths = contiguous_widths_u8(
+        timeline_entries
+            .iter()
+            .map(|(_, start, end)| (u32::from(*start), u32::from(*end))),
+    )?;
     fs::write(
         format!("{OUT_DIR}/baseline.rs"),
         quote! {
             static BASELINE_BROWSERS: &[u8] = &[#(#browser_tokens),*];
             static BASELINE_VERSIONS_BROWSER: &[u8] = &[#(#version_browser_tokens),*];
             static BASELINE_VERSIONS_VERSION: &[PooledStr] = &[#(#version_tokens),*];
-            static BASELINE_TIMELINE_DATE: &[u32] = &[#(#timeline_dates),*];
-            static BASELINE_TIMELINE_START: &[u16] = &[#(#timeline_starts),*];
-            static BASELINE_TIMELINE_END: &[u16] = &[#(#timeline_ends),*];
+            static BASELINE_TIMELINE_DATE_DELTA: &[u32] = &[#(#timeline_dates),*];
+            static BASELINE_TIMELINE_WIDTH: &[u8] = &[#(#timeline_widths),*];
         }
         .to_string(),
     )?;
@@ -602,6 +645,80 @@ fn run_node(script: &str) -> Result<String> {
         anyhow::bail!("node failed: {}", String::from_utf8_lossy(&out.stderr));
     }
     Ok(String::from_utf8(out.stdout)?)
+}
+
+/// Checks that the ranges tile the array end to end and returns just their widths;
+/// the starts are a prefix sum of these, rebuilt at load time.
+fn contiguous_widths(ranges: impl Iterator<Item = (u32, u32)>) -> Result<Vec<u32>> {
+    let mut widths = Vec::new();
+    let mut expected = 0;
+    for (start, end) in ranges {
+        anyhow::ensure!(start == expected, "ranges must be contiguous");
+        widths.push(end - start);
+        expected = end;
+    }
+    Ok(widths)
+}
+
+/// [`contiguous_widths`], for ranges narrow enough to hold a width in a byte.
+fn contiguous_widths_u8(ranges: impl Iterator<Item = (u32, u32)>) -> Result<Vec<u8>> {
+    contiguous_widths(ranges)?
+        .into_iter()
+        .map(|width| Ok(u8::try_from(width)?))
+        .collect()
+}
+
+/// Successive differences, zigzagged so they stay unsigned. Values that drift by a
+/// little compress far better this way; the array is summed back at load time.
+fn zigzag_delta(values: impl Iterator<Item = u32>) -> Vec<u32> {
+    let mut previous = 0i64;
+    values
+        .map(|value| {
+            let delta = i64::from(value) - previous;
+            previous = i64::from(value);
+            ((delta << 1) ^ (delta >> 63)) as u32
+        })
+        .collect()
+}
+
+/// A usage percentage as thousandths. Global usage tops out around 45%, so a `u16`
+/// holds it, and 0.001 is fine enough that no threshold query lands differently --
+/// checked by the comparison tests against the JS implementation, which do fail at
+/// hundredths.
+fn per_mille(value: f32) -> Result<u16> {
+    let scaled = (value * 1000.0).round();
+    anyhow::ensure!(
+        (0.0..65536.0).contains(&scaled),
+        "usage out of range: {value}"
+    );
+    // `> 0%` is a real query, so a usage that is small but not zero must not round down
+    // to zero; give it the smallest value that still counts as used.
+    if value > 0.0 && scaled == 0.0 {
+        return Ok(1);
+    }
+    Ok(scaled as u16)
+}
+
+/// A region usage percentage as hundred-thousandths. Region usage reaches 83%, which
+/// overflows a `u16` at any scale finer than hundredths, and the caniuse region data
+/// carries five decimals -- so this one stays 32 bits wide.
+fn per_100k(value: f32) -> Result<u32> {
+    let scaled = (value * 100_000.0).round();
+    anyhow::ensure!(
+        (0.0..4294967296.0).contains(&scaled),
+        "usage out of range: {value}"
+    );
+    Ok(scaled as u32)
+}
+
+/// An electron version as hundredths, which represents every released version exactly.
+fn hundredths(value: f32) -> Result<u16> {
+    let scaled = (value * 100.0).round();
+    anyhow::ensure!(
+        (0.0..65536.0).contains(&scaled),
+        "version out of range: {value}"
+    );
+    Ok(scaled as u16)
 }
 
 #[derive(Default)]

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -214,6 +214,17 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
     let data = parse_caniuse_global()?;
     let region_data = parse_caniuse_regions()?;
 
+    // One table of version strings, shared by every array that refers to a version, so
+    // those arrays hold a `u16` index instead of a four byte string id.
+    let mut version_ids = Vec::new();
+    for agent in data.agents.values() {
+        for version in &agent.version_list {
+            version_ids.push(strpool.insert(&version.version));
+        }
+    }
+    let (version_table, version_index) = intern_versions(version_ids.into_iter())?;
+    let version_table = version_table.iter().map(|id| quote! { PooledStr(#id) });
+
     // caniuse browsers
     {
         let mut versions = Vec::new();
@@ -256,6 +267,7 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
                 static VERSION_LIST_RELEASE_DATE_DELTA: &[u32] = &[#(#release_dates),*];
                 static VERSION_LIST_RELEASED: &[bool] = &[#(#released_flags),*];
                 static VERSION_LIST_GLOBAL_USAGE: &[u16] = &[#(#usages),*];
+                static VERSION_TABLE: &[PooledStr] = &[#(#version_table),*];
                 static BROWSERS_STATS_KEY: &[PooledStr] = &[#(#stat_keys),*];
                 static BROWSERS_STATS_WIDTH: &[u8] = &[#(#stat_widths),*];
             }
@@ -353,7 +365,16 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
                 .map(|(_, start, end)| (*start as u32, *end as u32)),
         )?;
 
-        let version_store = versions.iter();
+        let version_store = versions
+            .iter()
+            .map(|id| {
+                version_index
+                    .get(id)
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("feature version missing from the table"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let (version_store_lo, version_store_hi) = byte_planes(&version_store);
         let version_widths = contiguous_widths_u8(
             stats
                 .iter()
@@ -385,7 +406,8 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
                 static FEATURES_KEY_DELTA: &[u32] = &[#(#feature_keys),*];
                 static FEATURES_WIDTH: &[u8] = &[#(#feature_widths),*];
 
-                static FEATURES_STAT_VERSION_STORE: &[u32] = &[#(#version_store),*];
+                static FEATURES_STAT_VERSION_LO: &[u8] = &[#(#version_store_lo),*];
+                static FEATURES_STAT_VERSION_HI: &[u8] = &[#(#version_store_hi),*];
                 static FEATURES_STAT_VERSION_WIDTH: &[u8] = &[#(#version_widths),*];
 
                 static FEATURES_STAT_FLAGS: &[u8] = include_bytes!("caniuse-feature-flags.bin");
@@ -430,7 +452,16 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         fs::write(format!("{OUT_DIR}/caniuse-region-browsers.bin"), &browsers)?;
         drop(browsers);
 
-        let region_versions = usages.iter().map(|(_, v, _)| v);
+        let region_versions = usages
+            .iter()
+            .map(|(_, id, _)| {
+                version_index
+                    .get(id)
+                    .copied()
+                    .ok_or_else(|| anyhow::anyhow!("region version missing from the table"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let (region_versions_lo, region_versions_hi) = byte_planes(&region_versions);
         let region_percents = usages
             .iter()
             .map(|(.., usage)| per_100k(*usage))
@@ -457,7 +488,8 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
                 static REGIONS_WIDTH: &[u16] = &[#(#region_widths),*];
 
                 static REGIONS_BROWSERS: &[u8] = include_bytes!("caniuse-region-browsers.bin");
-                static REGIONS_VERSIONS: &[u32] = &[#(#region_versions),*];
+                static REGIONS_VERSION_LO: &[u8] = &[#(#region_versions_lo),*];
+                static REGIONS_VERSION_HI: &[u8] = &[#(#region_versions_hi),*];
                 static REGIONS_USAGES: &[u32] = &[#(#region_percents),*];
             }
             .to_string(),
@@ -666,6 +698,35 @@ fn contiguous_widths_u8(ranges: impl Iterator<Item = (u32, u32)>) -> Result<Vec<
         .into_iter()
         .map(|width| Ok(u8::try_from(width)?))
         .collect()
+}
+
+/// Splits a `u16` column into its low and high bytes, each kept contiguously. Every
+/// index here points into a table of a few hundred versions, so the high plane is
+/// almost entirely zero and all but vanishes once the data is compressed.
+fn byte_planes(values: &[u16]) -> (Vec<u8>, Vec<u8>) {
+    values
+        .iter()
+        .map(|value| ((value & 0xff) as u8, (value >> 8) as u8))
+        .unzip()
+}
+
+/// Interns version strings into one table shared by every reference to them, and
+/// returns the table alongside a lookup from string id to its `u16` index.
+fn intern_versions(ids: impl Iterator<Item = u32>) -> Result<(Vec<u32>, HashMap<u32, u16>)> {
+    let mut table = Vec::new();
+    let mut index = HashMap::new();
+    for id in ids {
+        if !index.contains_key(&id) {
+            index.insert(id, u16::try_from(table.len())?);
+            table.push(id);
+        }
+    }
+    anyhow::ensure!(
+        table.len() <= usize::from(u16::MAX),
+        "too many distinct versions to index with a u16: {}",
+        table.len()
+    );
+    Ok((table, index))
 }
 
 /// Successive differences, zigzagged so they stay unsigned. Values that drift by a

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
-    io::{self, Write},
+    io::Write,
 };
 
 const OUT_DIR: &str = "data/src/generated";
@@ -336,18 +336,9 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         let feature_starts = features.iter().map(|(_, start, _)| *start as u32);
         let feature_ends = features.iter().map(|(.., end)| *end as u32);
 
-        let version_store_len = write_u32(
-            format!("{OUT_DIR}/caniuse-feature-versionstore.u32seq"),
-            versions.iter().copied(),
-        )?;
-        let version_start_len = write_u32(
-            format!("{OUT_DIR}/caniuse-feature-versionstart.u32seq"),
-            stats.iter().map(|(_, start, _)| *start as u32),
-        )?;
-        let version_end_len = write_u32(
-            format!("{OUT_DIR}/caniuse-feature-versionend.u32seq"),
-            stats.iter().map(|(.., end)| *end as u32),
-        )?;
+        let version_store = versions.iter();
+        let version_starts = stats.iter().map(|(_, start, _)| *start as u32);
+        let version_ends = stats.iter().map(|(.., end)| *end as u32);
 
         fs::write(
             format!("{OUT_DIR}/caniuse-feature-flags.bin"),
@@ -365,28 +356,9 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
                 static FEATURES_START: &[u32] = &[#(#feature_starts),*];
                 static FEATURES_END: &[u32] = &[#(#feature_ends),*];
 
-                // # Safety
-                //
-                // We do the transmute at const context,
-                // and the size and alignment are already checked and guaranteed by compiler.
-                static FEATURES_STAT_VERSION_STORE: &[U32; #version_store_len / core::mem::size_of::<U32>()] = unsafe {
-                    &core::mem::transmute::<
-                        [u8; #version_store_len],
-                        [U32; #version_store_len / core::mem::size_of::<U32>()]
-                    >(*include_bytes!("caniuse-feature-versionstore.u32seq"))
-                };
-                static FEATURES_STAT_VERSION_START: &[U32; #version_start_len / core::mem::size_of::<U32>()] = unsafe {
-                    &core::mem::transmute::<
-                        [u8; #version_start_len],
-                        [U32; #version_start_len / core::mem::size_of::<U32>()]
-                    >(*include_bytes!("caniuse-feature-versionstart.u32seq"))
-                };
-                static FEATURES_STAT_VERSION_END: &[U32; #version_end_len / core::mem::size_of::<U32>()] = unsafe {
-                    &core::mem::transmute::<
-                        [u8; #version_end_len],
-                        [U32; #version_end_len / core::mem::size_of::<U32>()]
-                    >(*include_bytes!("caniuse-feature-versionend.u32seq"))
-                };
+                static FEATURES_STAT_VERSION_STORE: &[u32] = &[#(#version_store),*];
+                static FEATURES_STAT_VERSION_START: &[u32] = &[#(#version_starts),*];
+                static FEATURES_STAT_VERSION_END: &[u32] = &[#(#version_ends),*];
 
                 static FEATURES_STAT_FLAGS: &[u8] = include_bytes!("caniuse-feature-flags.bin");
                 static FEATURES_STAT_BROWSERS: &[u8] = include_bytes!("caniuse-feature-browsers.bin");
@@ -427,14 +399,8 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         fs::write(format!("{OUT_DIR}/caniuse-region-browsers.bin"), &browsers)?;
         drop(browsers);
 
-        let versions_len = write_u32(
-            format!("{OUT_DIR}/caniuse-region-versions.u32seq"),
-            usages.iter().map(|(_, v, _)| *v),
-        )?;
-        let usages_len = write_u32(
-            format!("{OUT_DIR}/caniuse-region-usages.u32seq"),
-            usages.iter().map(|(_, _, u)| u.to_bits()),
-        )?;
+        let region_versions = usages.iter().map(|(_, v, _)| v);
+        let region_percents = usages.iter().map(|(.., usage)| usage.to_bits());
 
         let region_keys = region_usages
             .iter()
@@ -450,19 +416,10 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
                 static REGIONS_END: &[u32] = &[#(#region_ends),*];
 
                 static REGIONS_BROWSERS: &[u8] = include_bytes!("caniuse-region-browsers.bin");
-                static REGIONS_VERSIONS: &[U32; #versions_len / core::mem::size_of::<U32>()] = unsafe {
-                    &core::mem::transmute::<
-                        [u8; #versions_len],
-                        [U32; #versions_len / core::mem::size_of::<U32>()]
-                    >(*include_bytes!("caniuse-region-versions.u32seq"))
-                };
-                static REGIONS_USAGES: &[U32; #usages_len / core::mem::size_of::<U32>()] = unsafe {
-                    &core::mem::transmute::<
-                        [u8; #usages_len],
-                        [U32; #usages_len / core::mem::size_of::<U32>()]
-                    >(*include_bytes!("caniuse-region-usages.u32seq"))
-                };
-            }.to_string()
+                static REGIONS_VERSIONS: &[u32] = &[#(#region_versions),*];
+                static REGIONS_USAGES: &[u32] = &[#(#region_percents),*];
+            }
+            .to_string(),
         )?;
     }
 
@@ -645,20 +602,6 @@ fn run_node(script: &str) -> Result<String> {
         anyhow::bail!("node failed: {}", String::from_utf8_lossy(&out.stderr));
     }
     Ok(String::from_utf8(out.stdout)?)
-}
-
-fn write_u32(path: String, iter: impl Iterator<Item = u32>) -> io::Result<usize> {
-    let fd = fs::File::create(path)?;
-    let mut fd = io::BufWriter::new(fd);
-    let mut n = 0;
-
-    for b in iter {
-        fd.write_all(&b.to_le_bytes())?;
-        n += 4;
-    }
-
-    fd.flush()?;
-    Ok(n)
 }
 
 #[derive(Default)]

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -173,34 +173,26 @@ fn build_node_release_schedule() -> Result<()> {
     // filter by end date to quickly reduce scope
     versions.sort_by_key(|(_, (_, end))| *end);
 
+    let date_token = |date: chrono::NaiveDateTime| {
+        let (year, month, day) = (date.year(), date.month(), date.day());
+        quote! { chrono::NaiveDate::from_ymd_opt(#year, #month, #day).unwrap() }
+    };
     let (versions, dates): (Vec<_>, Vec<_>) = versions
         .into_iter()
         .map(|(version, (start, end))| {
             let version = version.trim_start_matches('v');
-
-            let start_year = start.year();
-            let start_month = start.month();
-            let start_day = start.day();
-            let end_year = end.year();
-            let end_month = end.month();
-            let end_day = end.day();
-
-            let date = quote! {
-                (
-                    chrono::NaiveDate::from_ymd_opt(#start_year, #start_month, #start_day).unwrap(),
-                    chrono::NaiveDate::from_ymd_opt(#end_year, #end_month, #end_day).unwrap(),
-                )
-            };
-
-            (version.to_owned(), date)
+            (version.to_owned(), (date_token(start), date_token(end)))
         })
         .unzip();
+    let starts = dates.iter().map(|(start, _)| start);
+    let ends = dates.iter().map(|(_, end)| end);
 
     fs::write(
         path,
         quote! {
             static NODE_RELEASE_VERSIONS: &[&str] = &[#(#versions),*];
-            static NODE_RELEASE_SCHEDULE: &[(chrono::NaiveDate, chrono::NaiveDate)] = &[#(#dates),*];
+            static NODE_RELEASE_START: &[chrono::NaiveDate] = &[#(#starts),*];
+            static NODE_RELEASE_END: &[chrono::NaiveDate] = &[#(#ends),*];
         }
         .to_string(),
     )?;
@@ -215,6 +207,9 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
     // caniuse browsers
     {
         let mut versions = Vec::new();
+        let mut release_dates = Vec::new();
+        let mut released_flags = Vec::new();
+        let mut usages = Vec::new();
         let mut stats = Vec::new();
 
         for (name, agent) in &data.agents {
@@ -223,18 +218,10 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
 
             for version in &agent.version_list {
                 let version_str_id = strpool.insert(&version.version);
-                let usage = version.global_usage;
-                let date = version.release_date.unwrap_or_default();
-                let released = version.release_date.is_some();
-
-                versions.push(quote! {
-                    VersionDetail {
-                        version: PooledStr(#version_str_id),
-                        release_date: #date,
-                        released: #released,
-                        global_usage: #usage,
-                    }
-                });
+                versions.push(quote! { PooledStr(#version_str_id) });
+                release_dates.push(version.release_date.unwrap_or_default());
+                released_flags.push(version.release_date.is_some());
+                usages.push(version.global_usage);
             }
 
             let end: u32 = versions.len().try_into().unwrap();
@@ -242,20 +229,22 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         }
 
         stats.sort_by_key(|(name_str_id, ..)| strpool.get(*name_str_id));
-        let stats = stats.into_iter().map(|(name_str_id, start, end)| {
-            quote! {
-                (
-                    PooledStr(#name_str_id),
-                    BrowserStat(#start, #end)
-                )
-            }
-        });
+        let stat_keys = stats
+            .iter()
+            .map(|(name_str_id, ..)| quote! { PooledStr(#name_str_id) });
+        let stat_starts = stats.iter().map(|(_, start, _)| start);
+        let stat_ends = stats.iter().map(|(.., end)| end);
 
         fs::write(
             format!("{OUT_DIR}/caniuse-browsers.rs"),
             quote! {
-                static VERSION_LIST: &[VersionDetail] = &[#(#versions),*];
-                static BROWSERS_STATS: &[(PooledStr, BrowserStat)] = &[#(#stats),*];
+                static VERSION_LIST_VERSION: &[PooledStr] = &[#(#versions),*];
+                static VERSION_LIST_RELEASE_DATE: &[i64] = &[#(#release_dates),*];
+                static VERSION_LIST_RELEASED: &[bool] = &[#(#released_flags),*];
+                static VERSION_LIST_GLOBAL_USAGE: &[f32] = &[#(#usages),*];
+                static BROWSERS_STATS_KEY: &[PooledStr] = &[#(#stat_keys),*];
+                static BROWSERS_STATS_START: &[u32] = &[#(#stat_starts),*];
+                static BROWSERS_STATS_END: &[u32] = &[#(#stat_ends),*];
             }
             .to_string(),
         )?;
@@ -273,21 +262,19 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         }
 
         global_usage.sort_unstable_by(|(.., a), (.., b)| b.total_cmp(a));
-        let push_usage = global_usage
-            .into_iter()
-            .map(|(name_str_id, version_str_id, usage)| {
-                quote! {
-                    (
-                        PooledStr(#name_str_id),
-                        PooledStr(#version_str_id),
-                        #usage
-                    )
-                }
-            });
+        let browsers = global_usage
+            .iter()
+            .map(|(name_str_id, ..)| quote! { PooledStr(#name_str_id) });
+        let versions = global_usage
+            .iter()
+            .map(|(_, version_str_id, _)| quote! { PooledStr(#version_str_id) });
+        let usages = global_usage.iter().map(|(.., usage)| usage);
         fs::write(
             format!("{OUT_DIR}/caniuse-global-usage.rs"),
             quote! {
-                &[#(#push_usage),*]
+                static CANIUSE_GLOBAL_USAGE_BROWSER: &[PooledStr] = &[#(#browsers),*];
+                static CANIUSE_GLOBAL_USAGE_VERSION: &[PooledStr] = &[#(#versions),*];
+                static CANIUSE_GLOBAL_USAGE_USAGE: &[f32] = &[#(#usages),*];
             }
             .to_string(),
         )?;
@@ -339,33 +326,27 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
 
         features.sort_by_key(|(name, ..)| strpool.get(*name));
 
-        let (stats_name, stats_list): (Vec<_>, Vec<_>) = stats
+        let stats_name = stats
             .iter()
-            .map(|(browser, start, end)| {
-                let browser = encode_browser_name(browser);
-                let start: u32 = (*start).try_into().unwrap();
-                let end: u32 = (*end).try_into().unwrap();
-                (browser, [start, end])
-            })
-            .unzip();
-        let features = features.iter().flat_map(|(name_str_id, start, end)| {
-            let start: u32 = (*start).try_into().unwrap();
-            let end: u32 = (*end).try_into().unwrap();
-            quote! {
-                (
-                    PooledStr(#name_str_id),
-                    Feature(#start, #end)
-                )
-            }
-        });
+            .map(|(browser, ..)| encode_browser_name(browser))
+            .collect::<Vec<_>>();
+        let feature_keys = features
+            .iter()
+            .map(|(name_str_id, ..)| quote! { PooledStr(#name_str_id) });
+        let feature_starts = features.iter().map(|(_, start, _)| *start as u32);
+        let feature_ends = features.iter().map(|(.., end)| *end as u32);
 
         let version_store_len = write_u32(
             format!("{OUT_DIR}/caniuse-feature-versionstore.u32seq"),
             versions.iter().copied(),
         )?;
-        let version_index_len = write_u32(
-            format!("{OUT_DIR}/caniuse-feature-versionindex.u32seq"),
-            stats_list.iter().flatten().copied(),
+        let version_start_len = write_u32(
+            format!("{OUT_DIR}/caniuse-feature-versionstart.u32seq"),
+            stats.iter().map(|(_, start, _)| *start as u32),
+        )?;
+        let version_end_len = write_u32(
+            format!("{OUT_DIR}/caniuse-feature-versionend.u32seq"),
+            stats.iter().map(|(.., end)| *end as u32),
         )?;
 
         fs::write(
@@ -380,7 +361,9 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         fs::write(
             format!("{OUT_DIR}/caniuse-feature-matching.rs"),
             quote! {
-                static FEATURES: &[(PooledStr, Feature)] = &[#(#features),*];
+                static FEATURES_KEY: &[PooledStr] = &[#(#feature_keys),*];
+                static FEATURES_START: &[u32] = &[#(#feature_starts),*];
+                static FEATURES_END: &[u32] = &[#(#feature_ends),*];
 
                 // # Safety
                 //
@@ -392,11 +375,17 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
                         [U32; #version_store_len / core::mem::size_of::<U32>()]
                     >(*include_bytes!("caniuse-feature-versionstore.u32seq"))
                 };
-                static FEATURES_STAT_VERSION_INDEX: &[PairU32; #version_index_len / core::mem::size_of::<PairU32>()] = unsafe {
+                static FEATURES_STAT_VERSION_START: &[U32; #version_start_len / core::mem::size_of::<U32>()] = unsafe {
                     &core::mem::transmute::<
-                        [u8; #version_index_len],
-                        [PairU32; #version_index_len / core::mem::size_of::<PairU32>()]
-                    >(*include_bytes!("caniuse-feature-versionindex.u32seq"))
+                        [u8; #version_start_len],
+                        [U32; #version_start_len / core::mem::size_of::<U32>()]
+                    >(*include_bytes!("caniuse-feature-versionstart.u32seq"))
+                };
+                static FEATURES_STAT_VERSION_END: &[U32; #version_end_len / core::mem::size_of::<U32>()] = unsafe {
+                    &core::mem::transmute::<
+                        [u8; #version_end_len],
+                        [U32; #version_end_len / core::mem::size_of::<U32>()]
+                    >(*include_bytes!("caniuse-feature-versionend.u32seq"))
                 };
 
                 static FEATURES_STAT_FLAGS: &[u8] = include_bytes!("caniuse-feature-flags.bin");
@@ -447,25 +436,18 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
             usages.iter().map(|(_, _, u)| u.to_bits()),
         )?;
 
-        let region_data = region_usages
+        let region_keys = region_usages
             .iter()
-            .copied()
-            .map(|(region_str_id, start, end)| {
-                let start: u32 = start.try_into().unwrap();
-                let end: u32 = end.try_into().unwrap();
-
-                quote! {
-                    (
-                        PooledStr(#region_str_id),
-                        RegionData(#start, #end)
-                    )
-                }
-            });
+            .map(|(region_str_id, ..)| quote! { PooledStr(#region_str_id) });
+        let region_starts = region_usages.iter().map(|(_, start, _)| *start as u32);
+        let region_ends = region_usages.iter().map(|(.., end)| *end as u32);
 
         fs::write(
             format!("{OUT_DIR}/caniuse-region-matching.rs"),
             quote! {
-                static REGIONS: &[(PooledStr, RegionData)] = &[#(#region_data),*];
+                static REGIONS_KEY: &[PooledStr] = &[#(#region_keys),*];
+                static REGIONS_START: &[u32] = &[#(#region_starts),*];
+                static REGIONS_END: &[u32] = &[#(#region_ends),*];
 
                 static REGIONS_BROWSERS: &[u8] = include_bytes!("caniuse-region-browsers.bin");
                 static REGIONS_VERSIONS: &[U32; #versions_len / core::mem::size_of::<U32>()] = unsafe {
@@ -635,16 +617,20 @@ process.stdout.write(JSON.stringify(timeline));
     });
     let version_tokens = version_entries
         .iter()
-        .map(|(browser, version)| quote! { (#browser, PooledStr(#version)) });
-    let timeline_tokens = timeline_entries
-        .iter()
-        .map(|(date, start, end)| quote! { (#date, #start, #end) });
+        .map(|(_, version)| quote! { PooledStr(#version) });
+    let version_browser_tokens = version_entries.iter().map(|(browser, _)| browser);
+    let timeline_dates = timeline_entries.iter().map(|(date, ..)| date);
+    let timeline_starts = timeline_entries.iter().map(|(_, start, _)| start);
+    let timeline_ends = timeline_entries.iter().map(|(.., end)| end);
     fs::write(
         format!("{OUT_DIR}/baseline.rs"),
         quote! {
             static BASELINE_BROWSERS: &[u8] = &[#(#browser_tokens),*];
-            static BASELINE_VERSIONS: &[(u8, PooledStr)] = &[#(#version_tokens),*];
-            static BASELINE_TIMELINE: &[(u32, u16, u16)] = &[#(#timeline_tokens),*];
+            static BASELINE_VERSIONS_BROWSER: &[u8] = &[#(#version_browser_tokens),*];
+            static BASELINE_VERSIONS_VERSION: &[PooledStr] = &[#(#version_tokens),*];
+            static BASELINE_TIMELINE_DATE: &[u32] = &[#(#timeline_dates),*];
+            static BASELINE_TIMELINE_START: &[u16] = &[#(#timeline_starts),*];
+            static BASELINE_TIMELINE_END: &[u16] = &[#(#timeline_ends),*];
         }
         .to_string(),
     )?;

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -236,10 +236,20 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
         let mut released_flags = Vec::new();
         let mut usages = Vec::new();
         let mut stats = Vec::new();
+        let mut lex_order = Vec::new();
 
         for (name, agent) in &data.agents {
             let name_str_id = strpool.insert(name);
             let start: u32 = versions.len().try_into().unwrap();
+
+            // Feature lookups take a version string, but the version list is in release
+            // order; bundle the permutation that puts it in lexicographic order so that
+            // the lookup can binary search through it.
+            let mut order = (0..agent.version_list.len())
+                .map(u8::try_from)
+                .collect::<Result<Vec<_>, _>>()?;
+            order.sort_by_key(|position| &agent.version_list[usize::from(*position)].version);
+            lex_order.extend(order);
 
             for version in &agent.version_list {
                 let version_str_id = strpool.insert(&version.version);
@@ -253,6 +263,7 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
             stats.push((name_str_id, start, end));
         }
 
+        let lex_order = write_blob("caniuse-version-lex-order.bin", &lex_order)?;
         let (versions_lo, versions_hi) = byte_planes(&versions);
         let versions_lo = write_blob("caniuse-version-lo.bin", &versions_lo)?;
         let versions_hi = write_blob("caniuse-version-hi.bin", &versions_hi)?;
@@ -269,6 +280,7 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
         fs::write(
             format!("{OUT_DIR}/caniuse-browsers.rs"),
             quote! {
+                static VERSION_LIST_LEX_ORDER: Blob = #lex_order;
                 static VERSION_LIST_VERSION_LO: Blob = #versions_lo;
                 static VERSION_LIST_VERSION_HI: Blob = #versions_hi;
                 static VERSION_LIST_RELEASE_DATE_DELTA: &[u32] = &[#(#release_dates),*];
@@ -321,37 +333,39 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
     {
         let mut features = Vec::new();
         let mut stats = Vec::new();
-        let mut versions = Vec::new();
-        let mut flags = Vec::new();
+        let mut flags: Vec<u8> = Vec::new();
 
         for (name, feature) in &data.data {
             let start = stats.len();
             for (browser, ver) in &feature.stats {
-                let mut list = ver
-                    .iter()
-                    .map(|(version, flags)| {
-                        let version_str_id = strpool.insert(version);
+                let agent = data.agents.get(browser).ok_or_else(|| {
+                    anyhow::anyhow!("feature `{name}`: unknown browser `{browser}`")
+                })?;
+                // caniuse states every feature for every version of a browser, so no
+                // versions are stored here at all: the flags line up with the browser's
+                // own version list, position by position.
+                anyhow::ensure!(
+                    agent.version_list.len() == ver.len()
+                        && agent
+                            .version_list
+                            .iter()
+                            .all(|version| ver.contains_key(&version.version)),
+                    "feature `{name}` does not cover every version of `{browser}`"
+                );
 
-                        let mut bit: u8 = 0;
-                        if flags.contains('y') {
-                            bit |= 1;
-                        }
-                        if flags.contains('a') {
-                            bit |= 2;
-                        }
-                        (version_str_id, bit)
-                    })
-                    .collect::<Vec<_>>();
-
-                // we only use `.get()`, so the original order does not need to be preserved here
-                list.sort_by_key(|(x, _)| strpool.get(*x));
-
-                let start = versions.len();
-                versions.extend(list.iter().map(|(x, _)| *x));
-                flags.extend(list.iter().map(|(_, y)| *y));
-                let end = versions.len();
-
-                stats.push((browser.as_str(), start, end));
+                let start = flags.len();
+                flags.extend(agent.version_list.iter().map(|version| {
+                    let support = &ver[&version.version];
+                    let mut bit: u8 = 0;
+                    if support.contains('y') {
+                        bit |= 1;
+                    }
+                    if support.contains('a') {
+                        bit |= 2;
+                    }
+                    bit
+                }));
+                stats.push((browser.as_str(), start, flags.len()));
             }
             let end = stats.len();
 
@@ -377,13 +391,6 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
             )?,
         )?;
 
-        let version_store = versions
-            .iter()
-            .map(|id| versions_table.intern(*id))
-            .collect::<Result<Vec<_>>>()?;
-        let (version_store_lo, version_store_hi) = byte_planes(&version_store);
-        let version_store_lo = write_blob("caniuse-feature-version-lo.bin", &version_store_lo)?;
-        let version_store_hi = write_blob("caniuse-feature-version-hi.bin", &version_store_hi)?;
         let version_widths = write_blob(
             "caniuse-feature-version-width.bin",
             &contiguous_widths_u8(
@@ -412,8 +419,6 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
                 static FEATURES_KEY_DELTA: &[u32] = &[#(#feature_keys),*];
                 static FEATURES_WIDTH: Blob = #feature_widths;
 
-                static FEATURES_STAT_VERSION_LO: Blob = #version_store_lo;
-                static FEATURES_STAT_VERSION_HI: Blob = #version_store_hi;
                 static FEATURES_STAT_VERSION_WIDTH: Blob = #version_widths;
 
                 static FEATURES_STAT_FLAGS: Blob = #packed_flags;

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -734,11 +734,27 @@ fn contiguous_widths_u8(ranges: impl Iterator<Item = (u32, u32)>) -> Result<Vec<
         .collect()
 }
 
-/// Writes a byte array twice -- verbatim as `<name>`, and deflated as `<name>.deflate`
-/// with its inflated length prefixed -- and returns the declaration of a `Blob` static
-/// reading whichever one the `deflate` feature selects. Shipping both keeps the feature
-/// a plain compile-time switch, with no compressor in anyone's build graph.
+/// Writes a byte array as a `Blob`, run-length encoded into a `<stem>-count.bin`
+/// companion where that pays for itself. Expanding a run-length array costs a heap copy
+/// at load time, so it is only taken when it saves at least a third.
 fn write_blob(name: &str, bytes: &[u8]) -> Result<TokenStream> {
+    let (values, counts) = run_lengths(bytes);
+    if (values.len() + counts.len()) * 3 <= bytes.len() * 2 {
+        let stem = name.strip_suffix(".bin").unwrap_or(name);
+        let values = write_bytes(name, &values)?;
+        let counts = write_bytes(&format!("{stem}-count.bin"), &counts)?;
+        return Ok(quote! { Blob::rle(#values, #counts) });
+    }
+
+    let bytes = write_bytes(name, bytes)?;
+    Ok(quote! { Blob::new(#bytes) })
+}
+
+/// Writes a byte array twice -- verbatim as `<name>`, and deflated as `<name>.deflate`
+/// with its inflated length prefixed -- and returns the expression reading whichever one
+/// the `deflate` feature selects. Shipping both keeps the feature a plain compile-time
+/// switch, with no compressor in anyone's build graph.
+fn write_bytes(name: &str, bytes: &[u8]) -> Result<TokenStream> {
     fs::write(format!("{OUT_DIR}/{name}"), bytes)?;
 
     let mut deflated = (bytes.len() as u32).to_le_bytes().to_vec();
@@ -752,9 +768,28 @@ fn write_blob(name: &str, bytes: &[u8]) -> Result<TokenStream> {
             const BYTES: &[u8] = include_bytes!(#deflate_name);
             #[cfg(not(feature = "deflate"))]
             const BYTES: &[u8] = include_bytes!(#name);
-            Blob::new(BYTES)
+            BYTES
         }
     })
+}
+
+/// Splits an array into one value per run and one count per run, breaking up runs longer
+/// than a count byte can hold. Columns that are sorted, or that are the high plane of an
+/// index which never reaches its second byte, collapse to almost nothing; the array is
+/// expanded back at load time by `unrle`.
+fn run_lengths(bytes: &[u8]) -> (Vec<u8>, Vec<u8>) {
+    let mut runs: Vec<u8> = Vec::new();
+    let mut counts: Vec<u8> = Vec::new();
+    for byte in bytes {
+        match counts.last_mut() {
+            Some(count) if runs.last() == Some(byte) && *count < u8::MAX => *count += 1,
+            _ => {
+                runs.push(*byte);
+                counts.push(1);
+            }
+        }
+    }
+    (runs, counts)
 }
 
 /// Splits a `u32` column into four byte arrays, one per byte position.

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
 use indexmap::IndexMap;
+use miniz_oxide::deflate::compress_to_vec;
+use proc_macro2::TokenStream;
 use quote::quote;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -252,6 +254,8 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
         }
 
         let (versions_lo, versions_hi) = byte_planes(&versions);
+        let versions_lo = write_blob("caniuse-version-lo.bin", &versions_lo)?;
+        let versions_hi = write_blob("caniuse-version-hi.bin", &versions_hi)?;
         let release_dates = zigzag_delta(release_dates.into_iter());
 
         stats.sort_by_key(|(name_str_id, ..)| strpool.get(*name_str_id));
@@ -265,8 +269,8 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
         fs::write(
             format!("{OUT_DIR}/caniuse-browsers.rs"),
             quote! {
-                static VERSION_LIST_VERSION_LO: &[u8] = &[#(#versions_lo),*];
-                static VERSION_LIST_VERSION_HI: &[u8] = &[#(#versions_hi),*];
+                static VERSION_LIST_VERSION_LO: Blob = #versions_lo;
+                static VERSION_LIST_VERSION_HI: Blob = #versions_hi;
                 static VERSION_LIST_RELEASE_DATE_DELTA: &[u32] = &[#(#release_dates),*];
                 static VERSION_LIST_RELEASED: &[bool] = &[#(#released_flags),*];
                 static VERSION_LIST_GLOBAL_USAGE: &[u16] = &[#(#usages),*];
@@ -289,9 +293,14 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
         }
 
         global_usage.sort_unstable_by(|(.., a), (.., b)| b.total_cmp(a));
-        let browsers = global_usage.iter().map(|(browser, ..)| browser);
+        let browsers = write_blob(
+            "caniuse-global-usage-browser.bin",
+            &global_usage.iter().map(|(b, ..)| *b).collect::<Vec<_>>(),
+        )?;
         let (versions_lo, versions_hi) =
             byte_planes(&global_usage.iter().map(|(_, v, _)| *v).collect::<Vec<_>>());
+        let versions_lo = write_blob("caniuse-global-usage-version-lo.bin", &versions_lo)?;
+        let versions_hi = write_blob("caniuse-global-usage-version-hi.bin", &versions_hi)?;
         let usages = global_usage
             .iter()
             .map(|(.., usage)| per_mille(**usage))
@@ -299,9 +308,9 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
         fs::write(
             format!("{OUT_DIR}/caniuse-global-usage.rs"),
             quote! {
-                static CANIUSE_GLOBAL_USAGE_BROWSER: &[u8] = &[#(#browsers),*];
-                static CANIUSE_GLOBAL_USAGE_VERSION_LO: &[u8] = &[#(#versions_lo),*];
-                static CANIUSE_GLOBAL_USAGE_VERSION_HI: &[u8] = &[#(#versions_hi),*];
+                static CANIUSE_GLOBAL_USAGE_BROWSER: Blob = #browsers;
+                static CANIUSE_GLOBAL_USAGE_VERSION_LO: Blob = #versions_lo;
+                static CANIUSE_GLOBAL_USAGE_VERSION_HI: Blob = #versions_hi;
                 static CANIUSE_GLOBAL_USAGE_USAGE: &[u16] = &[#(#usages),*];
             }
             .to_string(),
@@ -359,10 +368,13 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
             .map(|(browser, ..)| encode_browser_name(browser))
             .collect::<Vec<_>>();
         let feature_keys = zigzag_delta(features.iter().map(|(name_str_id, ..)| *name_str_id));
-        let feature_widths = contiguous_widths_u8(
-            features
-                .iter()
-                .map(|(_, start, end)| (*start as u32, *end as u32)),
+        let feature_widths = write_blob(
+            "caniuse-feature-width.bin",
+            &contiguous_widths_u8(
+                features
+                    .iter()
+                    .map(|(_, start, end)| (*start as u32, *end as u32)),
+            )?,
         )?;
 
         let version_store = versions
@@ -370,10 +382,15 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
             .map(|id| versions_table.intern(*id))
             .collect::<Result<Vec<_>>>()?;
         let (version_store_lo, version_store_hi) = byte_planes(&version_store);
-        let version_widths = contiguous_widths_u8(
-            stats
-                .iter()
-                .map(|(_, start, end)| (*start as u32, *end as u32)),
+        let version_store_lo = write_blob("caniuse-feature-version-lo.bin", &version_store_lo)?;
+        let version_store_hi = write_blob("caniuse-feature-version-hi.bin", &version_store_hi)?;
+        let version_widths = write_blob(
+            "caniuse-feature-version-width.bin",
+            &contiguous_widths_u8(
+                stats
+                    .iter()
+                    .map(|(_, start, end)| (*start as u32, *end as u32)),
+            )?,
         )?;
 
         // Two bits per flag; only `y` and `a` are recorded.
@@ -386,28 +403,23 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
                     .fold(0u8, |byte, (i, flag)| byte | (flag << (2 * i)))
             })
             .collect::<Vec<_>>();
-        fs::write(
-            format!("{OUT_DIR}/caniuse-feature-flags.bin"),
-            packed_flags.as_slice(),
-        )?;
-        fs::write(
-            format!("{OUT_DIR}/caniuse-feature-browsers.bin"),
-            stats_name.as_slice(),
-        )?;
+        let packed_flags = write_blob("caniuse-feature-flags.bin", &packed_flags)?;
+        let stats_name = write_blob("caniuse-feature-browsers.bin", &stats_name)?;
 
         fs::write(
             format!("{OUT_DIR}/caniuse-feature-matching.rs"),
             quote! {
                 static FEATURES_KEY_DELTA: &[u32] = &[#(#feature_keys),*];
-                static FEATURES_WIDTH: &[u8] = &[#(#feature_widths),*];
+                static FEATURES_WIDTH: Blob = #feature_widths;
 
-                static FEATURES_STAT_VERSION_LO: &[u8] = &[#(#version_store_lo),*];
-                static FEATURES_STAT_VERSION_HI: &[u8] = &[#(#version_store_hi),*];
-                static FEATURES_STAT_VERSION_WIDTH: &[u8] = &[#(#version_widths),*];
+                static FEATURES_STAT_VERSION_LO: Blob = #version_store_lo;
+                static FEATURES_STAT_VERSION_HI: Blob = #version_store_hi;
+                static FEATURES_STAT_VERSION_WIDTH: Blob = #version_widths;
 
-                static FEATURES_STAT_FLAGS: &[u8] = include_bytes!("caniuse-feature-flags.bin");
-                static FEATURES_STAT_BROWSERS: &[u8] = include_bytes!("caniuse-feature-browsers.bin");
-            }.to_string()
+                static FEATURES_STAT_FLAGS: Blob = #packed_flags;
+                static FEATURES_STAT_BROWSERS: Blob = #stats_name;
+            }
+            .to_string(),
         )?;
     }
 
@@ -443,19 +455,31 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
 
         region_usages.sort_by_key(|(region, ..)| strpool.get(*region));
 
-        let browsers = usages.iter().map(|(b, ..)| *b).collect::<Vec<_>>();
-        fs::write(format!("{OUT_DIR}/caniuse-region-browsers.bin"), &browsers)?;
-        drop(browsers);
+        let browsers = write_blob(
+            "caniuse-region-browsers.bin",
+            &usages.iter().map(|(b, ..)| *b).collect::<Vec<_>>(),
+        )?;
 
         let region_versions = usages
             .iter()
             .map(|(_, id, _)| versions_table.intern(*id))
             .collect::<Result<Vec<_>>>()?;
         let (region_versions_lo, region_versions_hi) = byte_planes(&region_versions);
-        let region_percents = usages
+        let region_versions_lo = write_blob("caniuse-region-version-lo.bin", &region_versions_lo)?;
+        let region_versions_hi = write_blob("caniuse-region-version-hi.bin", &region_versions_hi)?;
+        let region_percents = u32_planes(
+            &usages
+                .iter()
+                .map(|(.., usage)| per_100k(*usage))
+                .collect::<Result<Vec<_>>>()?,
+        );
+        let [usage_0, usage_1, usage_2, usage_3] = region_percents
             .iter()
-            .map(|(.., usage)| per_100k(*usage))
-            .collect::<Result<Vec<_>>>()?;
+            .enumerate()
+            .map(|(i, plane)| write_blob(&format!("caniuse-region-usage-{i}.bin"), plane))
+            .collect::<Result<Vec<_>>>()?
+            .try_into()
+            .map_err(|_| anyhow::anyhow!("expected four usage planes"))?;
 
         let region_keys = zigzag_delta(
             region_usages
@@ -477,10 +501,13 @@ fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Re
                 static REGIONS_KEY_DELTA: &[u32] = &[#(#region_keys),*];
                 static REGIONS_WIDTH: &[u16] = &[#(#region_widths),*];
 
-                static REGIONS_BROWSERS: &[u8] = include_bytes!("caniuse-region-browsers.bin");
-                static REGIONS_VERSION_LO: &[u8] = &[#(#region_versions_lo),*];
-                static REGIONS_VERSION_HI: &[u8] = &[#(#region_versions_hi),*];
-                static REGIONS_USAGES: &[u32] = &[#(#region_percents),*];
+                static REGIONS_BROWSERS: Blob = #browsers;
+                static REGIONS_VERSION_LO: Blob = #region_versions_lo;
+                static REGIONS_VERSION_HI: Blob = #region_versions_hi;
+                static REGIONS_USAGE_0: Blob = #usage_0;
+                static REGIONS_USAGE_1: Blob = #usage_1;
+                static REGIONS_USAGE_2: Blob = #usage_2;
+                static REGIONS_USAGE_3: Blob = #usage_3;
             }
             .to_string(),
         )?;
@@ -641,7 +668,15 @@ process.stdout.write(JSON.stringify(timeline));
             .map(|(_, version)| versions_table.intern(*version))
             .collect::<Result<Vec<_>>>()?,
     );
-    let version_browser_tokens = version_entries.iter().map(|(browser, _)| browser);
+    let version_tokens_lo = write_blob("baseline-versions-version-lo.bin", &version_tokens_lo)?;
+    let version_tokens_hi = write_blob("baseline-versions-version-hi.bin", &version_tokens_hi)?;
+    let version_browser_tokens = write_blob(
+        "baseline-versions-browser.bin",
+        &version_entries
+            .iter()
+            .map(|(browser, _)| *browser)
+            .collect::<Vec<_>>(),
+    )?;
     let timeline_dates = zigzag_delta(timeline_entries.iter().map(|(date, ..)| *date));
     let timeline_widths = contiguous_widths_u8(
         timeline_entries
@@ -652,9 +687,9 @@ process.stdout.write(JSON.stringify(timeline));
         format!("{OUT_DIR}/baseline.rs"),
         quote! {
             static BASELINE_BROWSERS: &[u8] = &[#(#browser_tokens),*];
-            static BASELINE_VERSIONS_BROWSER: &[u8] = &[#(#version_browser_tokens),*];
-            static BASELINE_VERSIONS_VERSION_LO: &[u8] = &[#(#version_tokens_lo),*];
-            static BASELINE_VERSIONS_VERSION_HI: &[u8] = &[#(#version_tokens_hi),*];
+            static BASELINE_VERSIONS_BROWSER: Blob = #version_browser_tokens;
+            static BASELINE_VERSIONS_VERSION_LO: Blob = #version_tokens_lo;
+            static BASELINE_VERSIONS_VERSION_HI: Blob = #version_tokens_hi;
             static BASELINE_TIMELINE_DATE_DELTA: &[u32] = &[#(#timeline_dates),*];
             static BASELINE_TIMELINE_WIDTH: &[u8] = &[#(#timeline_widths),*];
         }
@@ -692,6 +727,40 @@ fn contiguous_widths_u8(ranges: impl Iterator<Item = (u32, u32)>) -> Result<Vec<
         .into_iter()
         .map(|width| Ok(u8::try_from(width)?))
         .collect()
+}
+
+/// Writes a byte array twice -- verbatim as `<name>`, and deflated as `<name>.deflate`
+/// with its inflated length prefixed -- and returns the declaration of a `Blob` static
+/// reading whichever one the `deflate` feature selects. Shipping both keeps the feature
+/// a plain compile-time switch, with no compressor in anyone's build graph.
+fn write_blob(name: &str, bytes: &[u8]) -> Result<TokenStream> {
+    fs::write(format!("{OUT_DIR}/{name}"), bytes)?;
+
+    let mut deflated = (bytes.len() as u32).to_le_bytes().to_vec();
+    deflated.extend(compress_to_vec(bytes, 10));
+    fs::write(format!("{OUT_DIR}/{name}.deflate"), &deflated)?;
+
+    let deflate_name = format!("{name}.deflate");
+    Ok(quote! {
+        {
+            #[cfg(feature = "deflate")]
+            const BYTES: &[u8] = include_bytes!(#deflate_name);
+            #[cfg(not(feature = "deflate"))]
+            const BYTES: &[u8] = include_bytes!(#name);
+            Blob::new(BYTES)
+        }
+    })
+}
+
+/// Splits a `u32` column into four byte arrays, one per byte position.
+fn u32_planes(values: &[u32]) -> [Vec<u8>; 4] {
+    let mut planes = [const { Vec::new() }; 4];
+    for value in values {
+        for (plane, byte) in planes.iter_mut().zip(value.to_le_bytes()) {
+            plane.push(byte);
+        }
+    }
+    planes
 }
 
 /// Splits a `u16` column into its low and high bytes, each kept contiguously. Every

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -66,9 +66,22 @@ fn main() -> Result<()> {
     build_node_release_schedule()?;
 
     let mut strpool = StrPool::default();
-    build_caniuse(&mut strpool)?;
-    build_baseline(&mut strpool)?;
+    let mut versions_table = VersionTable::default();
+    build_caniuse(&mut strpool, &mut versions_table)?;
+    build_baseline(&mut strpool, &mut versions_table)?;
     fs::write(format!("{OUT_DIR}/strpool.bin"), strpool.pool.as_bytes())?;
+
+    let versions = versions_table
+        .ids
+        .iter()
+        .map(|id| quote! { PooledStr(#id) });
+    fs::write(
+        format!("{OUT_DIR}/version-table.rs"),
+        quote! {
+            static VERSION_TABLE: &[PooledStr] = &[#(#versions),*];
+        }
+        .to_string(),
+    )?;
 
     Ok(())
 }
@@ -210,20 +223,9 @@ fn build_node_release_schedule() -> Result<()> {
     Ok(())
 }
 
-fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
+fn build_caniuse(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Result<()> {
     let data = parse_caniuse_global()?;
     let region_data = parse_caniuse_regions()?;
-
-    // One table of version strings, shared by every array that refers to a version, so
-    // those arrays hold a `u16` index instead of a four byte string id.
-    let mut version_ids = Vec::new();
-    for agent in data.agents.values() {
-        for version in &agent.version_list {
-            version_ids.push(strpool.insert(&version.version));
-        }
-    }
-    let (version_table, version_index) = intern_versions(version_ids.into_iter())?;
-    let version_table = version_table.iter().map(|id| quote! { PooledStr(#id) });
 
     // caniuse browsers
     {
@@ -239,7 +241,7 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
 
             for version in &agent.version_list {
                 let version_str_id = strpool.insert(&version.version);
-                versions.push(version_str_id);
+                versions.push(versions_table.intern(version_str_id)?);
                 release_dates.push(u32::try_from(version.release_date.unwrap_or_default())?);
                 released_flags.push(version.release_date.is_some());
                 usages.push(per_mille(version.global_usage)?);
@@ -249,7 +251,7 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
             stats.push((name_str_id, start, end));
         }
 
-        let versions = zigzag_delta(versions.into_iter());
+        let (versions_lo, versions_hi) = byte_planes(&versions);
         let release_dates = zigzag_delta(release_dates.into_iter());
 
         stats.sort_by_key(|(name_str_id, ..)| strpool.get(*name_str_id));
@@ -263,11 +265,11 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         fs::write(
             format!("{OUT_DIR}/caniuse-browsers.rs"),
             quote! {
-                static VERSION_LIST_VERSION_DELTA: &[u32] = &[#(#versions),*];
+                static VERSION_LIST_VERSION_LO: &[u8] = &[#(#versions_lo),*];
+                static VERSION_LIST_VERSION_HI: &[u8] = &[#(#versions_hi),*];
                 static VERSION_LIST_RELEASE_DATE_DELTA: &[u32] = &[#(#release_dates),*];
                 static VERSION_LIST_RELEASED: &[bool] = &[#(#released_flags),*];
                 static VERSION_LIST_GLOBAL_USAGE: &[u16] = &[#(#usages),*];
-                static VERSION_TABLE: &[PooledStr] = &[#(#version_table),*];
                 static BROWSERS_STATS_KEY: &[PooledStr] = &[#(#stat_keys),*];
                 static BROWSERS_STATS_WIDTH: &[u8] = &[#(#stat_widths),*];
             }
@@ -279,20 +281,17 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
     {
         let mut global_usage = Vec::new();
         for (name, agent) in &data.agents {
-            let name_str_id = strpool.insert(name);
+            let browser = encode_browser_name(name);
             for (version, usage) in &agent.usage_global {
                 let version_str_id = strpool.insert(version);
-                global_usage.push((name_str_id, version_str_id, usage));
+                global_usage.push((browser, versions_table.intern(version_str_id)?, usage));
             }
         }
 
         global_usage.sort_unstable_by(|(.., a), (.., b)| b.total_cmp(a));
-        let browsers = global_usage
-            .iter()
-            .map(|(name_str_id, ..)| quote! { PooledStr(#name_str_id) });
-        let versions = global_usage
-            .iter()
-            .map(|(_, version_str_id, _)| quote! { PooledStr(#version_str_id) });
+        let browsers = global_usage.iter().map(|(browser, ..)| browser);
+        let (versions_lo, versions_hi) =
+            byte_planes(&global_usage.iter().map(|(_, v, _)| *v).collect::<Vec<_>>());
         let usages = global_usage
             .iter()
             .map(|(.., usage)| per_mille(**usage))
@@ -300,8 +299,9 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         fs::write(
             format!("{OUT_DIR}/caniuse-global-usage.rs"),
             quote! {
-                static CANIUSE_GLOBAL_USAGE_BROWSER: &[PooledStr] = &[#(#browsers),*];
-                static CANIUSE_GLOBAL_USAGE_VERSION: &[PooledStr] = &[#(#versions),*];
+                static CANIUSE_GLOBAL_USAGE_BROWSER: &[u8] = &[#(#browsers),*];
+                static CANIUSE_GLOBAL_USAGE_VERSION_LO: &[u8] = &[#(#versions_lo),*];
+                static CANIUSE_GLOBAL_USAGE_VERSION_HI: &[u8] = &[#(#versions_hi),*];
                 static CANIUSE_GLOBAL_USAGE_USAGE: &[u16] = &[#(#usages),*];
             }
             .to_string(),
@@ -367,12 +367,7 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
 
         let version_store = versions
             .iter()
-            .map(|id| {
-                version_index
-                    .get(id)
-                    .copied()
-                    .ok_or_else(|| anyhow::anyhow!("feature version missing from the table"))
-            })
+            .map(|id| versions_table.intern(*id))
             .collect::<Result<Vec<_>>>()?;
         let (version_store_lo, version_store_hi) = byte_planes(&version_store);
         let version_widths = contiguous_widths_u8(
@@ -454,12 +449,7 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
 
         let region_versions = usages
             .iter()
-            .map(|(_, id, _)| {
-                version_index
-                    .get(id)
-                    .copied()
-                    .ok_or_else(|| anyhow::anyhow!("region version missing from the table"))
-            })
+            .map(|(_, id, _)| versions_table.intern(*id))
             .collect::<Result<Vec<_>>>()?;
         let (region_versions_lo, region_versions_hi) = byte_planes(&region_versions);
         let region_percents = usages
@@ -554,7 +544,7 @@ process.stdout.write(JSON.stringify(result));
     Ok(serde_json::from_str(&json)?)
 }
 
-fn build_baseline(strpool: &mut StrPool) -> Result<()> {
+fn build_baseline(strpool: &mut StrPool, versions_table: &mut VersionTable) -> Result<()> {
     #[derive(Deserialize)]
     struct TimelineEvent {
         date: String,
@@ -645,9 +635,12 @@ process.stdout.write(JSON.stringify(timeline));
         let id = encode_browser_name(name);
         quote! { #id }
     });
-    let version_tokens = version_entries
-        .iter()
-        .map(|(_, version)| quote! { PooledStr(#version) });
+    let (version_tokens_lo, version_tokens_hi) = byte_planes(
+        &version_entries
+            .iter()
+            .map(|(_, version)| versions_table.intern(*version))
+            .collect::<Result<Vec<_>>>()?,
+    );
     let version_browser_tokens = version_entries.iter().map(|(browser, _)| browser);
     let timeline_dates = zigzag_delta(timeline_entries.iter().map(|(date, ..)| *date));
     let timeline_widths = contiguous_widths_u8(
@@ -660,7 +653,8 @@ process.stdout.write(JSON.stringify(timeline));
         quote! {
             static BASELINE_BROWSERS: &[u8] = &[#(#browser_tokens),*];
             static BASELINE_VERSIONS_BROWSER: &[u8] = &[#(#version_browser_tokens),*];
-            static BASELINE_VERSIONS_VERSION: &[PooledStr] = &[#(#version_tokens),*];
+            static BASELINE_VERSIONS_VERSION_LO: &[u8] = &[#(#version_tokens_lo),*];
+            static BASELINE_VERSIONS_VERSION_HI: &[u8] = &[#(#version_tokens_hi),*];
             static BASELINE_TIMELINE_DATE_DELTA: &[u32] = &[#(#timeline_dates),*];
             static BASELINE_TIMELINE_WIDTH: &[u8] = &[#(#timeline_widths),*];
         }
@@ -710,23 +704,24 @@ fn byte_planes(values: &[u16]) -> (Vec<u8>, Vec<u8>) {
         .unzip()
 }
 
-/// Interns version strings into one table shared by every reference to them, and
-/// returns the table alongside a lookup from string id to its `u16` index.
-fn intern_versions(ids: impl Iterator<Item = u32>) -> Result<(Vec<u32>, HashMap<u32, u16>)> {
-    let mut table = Vec::new();
-    let mut index = HashMap::new();
-    for id in ids {
-        if !index.contains_key(&id) {
-            index.insert(id, u16::try_from(table.len())?);
-            table.push(id);
+/// One table of version strings, shared by every array that refers to a version so
+/// that each reference costs a `u16` index rather than a four byte string id.
+#[derive(Default)]
+struct VersionTable {
+    ids: Vec<u32>,
+    index: HashMap<u32, u16>,
+}
+
+impl VersionTable {
+    fn intern(&mut self, id: u32) -> Result<u16> {
+        if let Some(index) = self.index.get(&id) {
+            return Ok(*index);
         }
+        let index = u16::try_from(self.ids.len())?;
+        self.index.insert(id, index);
+        self.ids.push(id);
+        Ok(index)
     }
-    anyhow::ensure!(
-        table.len() <= usize::from(u16::MAX),
-        "too many distinct versions to index with a u16: {}",
-        table.len()
-    );
-    Ok((table, index))
 }
 
 /// Successive differences, zigzagged so they stay unsigned. Values that drift by a

--- a/src/queries/cover_by_region.rs
+++ b/src/queries/cover_by_region.rs
@@ -11,7 +11,12 @@ pub(super) fn cover_by_region(coverage: f32, region: &str) -> QueryResult {
     };
 
     if let Some(region_data) = get_usage_by_region(&normalized_region) {
-        let result = region_data.iter().try_fold(
+        // The data is bundled in canonical browser order, which is the order that
+        // compresses; this query is the only one that needs it by usage instead. The
+        // sort is stable, so equal usages keep the canonical order.
+        let mut entries = region_data.iter().collect::<Vec<_>>();
+        entries.sort_by(|(_, _, a), (_, _, b)| b.total_cmp(a));
+        let result = entries.into_iter().try_fold(
             (vec![], 0.0),
             |(mut distribs, total), (name, version, usage)| {
                 if total >= coverage || usage == 0.0 {


### PR DESCRIPTION
Performed my best-effort to shrink the binary size w/o sacrifice the correctness.

Leave the new `deflate` feature by default disabled, as if user has `upx`-like after build it will be a regression.

|                    |   main    |      current       | current (deflate)  |
|--------------------|-----------|--------------------|--------------------|
| stripped total     | 3,957,424 | 1,630,400 (−58.8%) | 1,524,984 (−61.5%) |
| `.rodata`            | 2,714,588 |   358,436 (−86.8%) |   237,092 (−91.3%) |
| `.text`              |   984,195 |  1,005,107 (+2.1%) |  1,018,067 (+3.4%) |
| `.data.rel.ro`       |    32,168 |     33,096 (+2.9%) |     34,056 (+5.9%) |
| zstd -19 of binary |   680,843 |    628,165 (−7.7%) |    639,044 (−6.1%) |

I will detail the modifications later.