### PR TITLE
perf: drop derivable caniuse data

### DIFF
--- a/data/src/caniuse.rs
+++ b/data/src/caniuse.rs
@@ -25,8 +25,21 @@ include!("generated/caniuse-browsers.rs");
 
 static CANIUSE_BROWSERS: BinMap<PooledStr, BrowserStat> = BinMap(BROWSERS_STATS);
 
-static CANIUSE_GLOBAL_USAGE: &[(PooledStr, PooledStr, f32)] =
-    include!("generated/caniuse-global-usage.rs");
+/// Every version carries its own global usage, and caniuse lists a usage for exactly the
+/// versions in the version list, so the usage table is that data sorted by usage.
+static CANIUSE_GLOBAL_USAGE: LazyLock<Vec<(&'static str, &'static str, f32)>> =
+    LazyLock::new(|| {
+        let mut usage = CANIUSE_BROWSERS
+            .iter()
+            .flat_map(|(name, stat)| {
+                stat.version_list()
+                    .iter()
+                    .map(|version| (name.as_str(), version.version(), version.global_usage))
+            })
+            .collect::<Vec<_>>();
+        usage.sort_unstable_by(|(.., a), (.., b)| b.total_cmp(a));
+        usage
+    });
 
 static BROWSER_VERSION_ALIASES: LazyLock<
     AHashMap<&'static str, AHashMap<&'static str, &'static str>>,
@@ -159,10 +172,7 @@ pub fn iter_browser_stat(
 }
 
 pub fn iter_global_usage() -> impl ExactSizeIterator<Item = (&'static str, &'static str, f32)> {
-    CANIUSE_GLOBAL_USAGE
-        .iter()
-        .copied()
-        .map(|(name, version, usage)| (name.as_str(), version.as_str(), usage))
+    CANIUSE_GLOBAL_USAGE.iter().copied()
 }
 
 pub fn get_browser_version_alias(name: &str, version: &str) -> Option<&'static str> {
@@ -221,10 +231,18 @@ pub fn normalize_version<'a>(
     }
 }
 
+/// Looks up one browser by name, for the feature tables to resolve versions through.
+pub(crate) fn browser_stat(name: &str) -> Option<&'static BrowserStat> {
+    CANIUSE_BROWSERS.get(name)
+}
+
 impl BrowserStat {
     pub fn version_list(&self) -> &'static [VersionDetail] {
-        let range = (self.0 as usize)..(self.1 as usize);
-        &VERSION_LIST[range]
+        &VERSION_LIST[self.range()]
+    }
+
+    fn range(&self) -> std::ops::Range<usize> {
+        (self.0 as usize)..(self.1 as usize)
     }
 }
 

--- a/data/src/caniuse.rs
+++ b/data/src/caniuse.rs
@@ -41,6 +41,24 @@ static CANIUSE_GLOBAL_USAGE: LazyLock<Vec<(&'static str, &'static str, f32)>> =
         usage
     });
 
+/// Position of every version within its own browser's version list. The feature tables
+/// store one flag per version in that same order, so a position is also a flag offset.
+static VERSION_INDEXES: LazyLock<AHashMap<&'static str, AHashMap<&'static str, u32>>> =
+    LazyLock::new(|| {
+        CANIUSE_BROWSERS
+            .iter()
+            .map(|(name, stat)| {
+                let indexes = stat
+                    .version_list()
+                    .iter()
+                    .enumerate()
+                    .map(|(index, version)| (version.version(), index as u32))
+                    .collect();
+                (name.as_str(), indexes)
+            })
+            .collect()
+    });
+
 static BROWSER_VERSION_ALIASES: LazyLock<
     AHashMap<&'static str, AHashMap<&'static str, &'static str>>,
 > = LazyLock::new(|| {
@@ -234,6 +252,11 @@ pub fn normalize_version<'a>(
 /// Looks up one browser by name, for the feature tables to resolve versions through.
 pub(crate) fn browser_stat(name: &str) -> Option<&'static BrowserStat> {
     CANIUSE_BROWSERS.get(name)
+}
+
+/// One browser's slice of [`VERSION_INDEXES`], for the feature tables to look versions up in.
+pub(crate) fn version_indexes(name: &str) -> Option<&'static AHashMap<&'static str, u32>> {
+    VERSION_INDEXES.get(name)
 }
 
 impl BrowserStat {

--- a/data/src/caniuse/features.rs
+++ b/data/src/caniuse/features.rs
@@ -1,5 +1,6 @@
-use super::{PooledStr, VersionDetail};
+use super::PooledStr;
 use crate::{decode_browser_name, utils::BinMap};
+use ahash::AHashMap;
 use std::sync::LazyLock;
 
 #[derive(Clone, Copy)]
@@ -7,8 +8,9 @@ pub struct Feature(u32, u32);
 
 #[derive(Clone, Copy)]
 pub struct VersionList {
-    // The browser's own version list, in release order.
-    versions: &'static [VersionDetail],
+    // Where each of the browser's versions sits in its version list, which is also where
+    // that version's flag sits within the browser's run of flags.
+    indexes: &'static AHashMap<&'static str, u32>,
     // Index of this browser's first flag within FEATURES_STAT_FLAGS.
     base: u32,
 }
@@ -45,9 +47,9 @@ fn browser_of(id: u8) -> &'static super::BrowserStat {
 }
 
 fn version_list_at(index: usize) -> VersionList {
-    let stat = browser_of(FEATURES_STAT_BROWSERS[index]);
+    let name = decode_browser_name(FEATURES_STAT_BROWSERS[index]);
     VersionList {
-        versions: stat.version_list(),
+        indexes: super::version_indexes(name).expect("feature refers to unknown browser"),
         base: FEATURES_STAT_FLAG_START[index],
     }
 }
@@ -72,10 +74,7 @@ impl Feature {
 
 impl VersionList {
     pub fn get(&self, version: &str) -> Option<u8> {
-        let position = self
-            .versions
-            .iter()
-            .position(|probe| probe.version() == version)?;
-        Some(FEATURES_STAT_FLAGS[self.base as usize + position])
+        let position = *self.indexes.get(version)?;
+        Some(FEATURES_STAT_FLAGS[self.base as usize + position as usize])
     }
 }

--- a/data/src/caniuse/features.rs
+++ b/data/src/caniuse/features.rs
@@ -1,28 +1,55 @@
-use super::PooledStr;
-use crate::{
-    decode_browser_name,
-    utils::{BinMap, PairU32, U32},
-};
+use super::{PooledStr, VersionDetail};
+use crate::{decode_browser_name, utils::BinMap};
+use std::sync::LazyLock;
 
 #[derive(Clone, Copy)]
 pub struct Feature(u32, u32);
 
 #[derive(Clone, Copy)]
-pub struct VersionList(PairU32);
+pub struct VersionList {
+    // The browser's own version list, in release order.
+    versions: &'static [VersionDetail],
+    // Index of this browser's first flag within FEATURES_STAT_FLAGS.
+    base: u32,
+}
 
 // ```rust
 // static FEATURES: &[(PooledStr, Feature)]; // feature name and browsers list
-//
-// static FEATURES_STAT_VERSION_STORE: &[U32]; // version string
-// static FEATURES_STAT_VERSION_INDEX: &[PairU32]; // version range
 //
 // static FEATURES_STAT_FLAGS: &[u8]; // support flag
 // static FEATURES_STAT_BROWSERS: &[u8]; // browser name id
 // ```
 include!("../generated/caniuse-feature-matching.rs");
 
+// caniuse states every feature for every version of a browser (checked by
+// generate-data), so a browser's flags line up with its version list position by
+// position, and each browser's run of flags is as long as its version list.
+static FEATURES_STAT_FLAG_START: LazyLock<Vec<u32>> = LazyLock::new(|| {
+    let mut start = 0;
+    FEATURES_STAT_BROWSERS
+        .iter()
+        .map(|id| {
+            let base = start;
+            start += browser_of(*id).version_list().len() as u32;
+            base
+        })
+        .collect()
+});
+
 pub fn get_feature_stat(name: &str) -> Option<Feature> {
     BinMap(FEATURES).get(name).copied()
+}
+
+fn browser_of(id: u8) -> &'static super::BrowserStat {
+    super::browser_stat(decode_browser_name(id)).expect("feature refers to unknown browser")
+}
+
+fn version_list_at(index: usize) -> VersionList {
+    let stat = browser_of(FEATURES_STAT_BROWSERS[index]);
+    VersionList {
+        versions: stat.version_list(),
+        base: FEATURES_STAT_FLAG_START[index],
+    }
 }
 
 impl Feature {
@@ -31,25 +58,24 @@ impl Feature {
         let index = FEATURES_STAT_BROWSERS[range.clone()]
             .binary_search_by_key(&browser, |&k| decode_browser_name(k))
             .ok()?;
-        let list = FEATURES_STAT_VERSION_INDEX[range][index];
-        Some(VersionList(list))
+        Some(version_list_at(range.start + index))
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&'static str, VersionList)> {
-        let range = (self.0 as usize)..(self.1 as usize);
-        FEATURES_STAT_BROWSERS[range.clone()]
+        let start = self.0 as usize;
+        FEATURES_STAT_BROWSERS[start..(self.1 as usize)]
             .iter()
-            .zip(&FEATURES_STAT_VERSION_INDEX[range])
-            .map(|(&name, &list)| (decode_browser_name(name), VersionList(list)))
+            .enumerate()
+            .map(move |(offset, &id)| (decode_browser_name(id), version_list_at(start + offset)))
     }
 }
 
 impl VersionList {
     pub fn get(&self, version: &str) -> Option<u8> {
-        let range = (self.0.0.get() as usize)..(self.0.1.get() as usize);
-        let index = FEATURES_STAT_VERSION_STORE[range.clone()]
-            .binary_search_by_key(&version, |s| PooledStr(s.get()).as_str())
-            .ok()?;
-        Some(FEATURES_STAT_FLAGS[range][index])
+        let position = self
+            .versions
+            .iter()
+            .position(|probe| probe.version() == version)?;
+        Some(FEATURES_STAT_FLAGS[self.base as usize + position])
     }
 }

--- a/data/src/caniuse/region.rs
+++ b/data/src/caniuse/region.rs
@@ -1,8 +1,5 @@
 use super::PooledStr;
-use crate::{
-    decode_browser_name,
-    utils::{BinMap, U32},
-};
+use crate::{decode_browser_name, utils::BinMap};
 
 #[derive(Clone, Copy)]
 pub struct RegionData(u32, u32);
@@ -11,8 +8,8 @@ pub struct RegionData(u32, u32);
 // static REGIONS: &[(PooledStr, RegionData)]; // region name and region data
 //
 // static REGIONS_BROWSERS: &[u8]; // browser name id
-// static REGIONS_VERSIONS: &[U32]; // version string
-// static REGIONS_USAGES: &[U32]; // browser usage (f32)
+// static REGIONS_VERSIONS: &[u32]; // version string
+// static REGIONS_USAGES: &[u32]; // browser usage (f32)
 // ```
 include!("../generated/caniuse-region-matching.rs");
 
@@ -31,8 +28,8 @@ impl RegionData {
             .map(|((browser, version), usage)| {
                 (
                     decode_browser_name(*browser),
-                    PooledStr(version.get()).as_str(),
-                    f32::from_bits(usage.get()),
+                    PooledStr(*version).as_str(),
+                    f32::from_bits(*usage),
                 )
             })
     }

--- a/data/src/utils.rs
+++ b/data/src/utils.rs
@@ -29,7 +29,8 @@ impl<K, V> BinMap<'_, K, V> {
     }
 }
 
-// We define repr C instead of using tuple to ensure a stable memory layout.
+// We define repr C to ensure a stable memory layout, since these are transmuted from
+// the bytes of the generated `.u32seq` files.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub(super) struct U32(u32);

--- a/data/src/utils.rs
+++ b/data/src/utils.rs
@@ -32,10 +32,6 @@ impl<K, V> BinMap<'_, K, V> {
 // We define repr C instead of using tuple to ensure a stable memory layout.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
-pub(super) struct PairU32(pub U32, pub U32);
-
-#[derive(Clone, Copy, Debug)]
-#[repr(C)]
 pub(super) struct U32(u32);
 
 impl U32 {

--- a/data/src/utils.rs
+++ b/data/src/utils.rs
@@ -29,18 +29,6 @@ impl<K, V> BinMap<'_, K, V> {
     }
 }
 
-// We define repr C to ensure a stable memory layout, since these are transmuted from
-// the bytes of the generated `.u32seq` files.
-#[derive(Clone, Copy, Debug)]
-#[repr(C)]
-pub(super) struct U32(u32);
-
-impl U32 {
-    pub const fn get(self) -> u32 {
-        self.0.to_le()
-    }
-}
-
 #[derive(Clone, Copy)]
 pub(super) struct PooledStr(pub(super) u32);
 

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
-    io::{self, Write},
+    io::Write,
 };
 
 const OUT_DIR: &str = "data/src/generated";
@@ -379,14 +379,8 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         fs::write(format!("{OUT_DIR}/caniuse-region-browsers.bin"), &browsers)?;
         drop(browsers);
 
-        let versions_len = write_u32(
-            format!("{OUT_DIR}/caniuse-region-versions.u32seq"),
-            usages.iter().map(|(_, v, _)| *v),
-        )?;
-        let usages_len = write_u32(
-            format!("{OUT_DIR}/caniuse-region-usages.u32seq"),
-            usages.iter().map(|(_, _, u)| u.to_bits()),
-        )?;
+        let versions = usages.iter().map(|(_, v, _)| *v);
+        let region_usages_bits = usages.iter().map(|(_, _, u)| u.to_bits());
 
         let region_data = region_usages
             .iter()
@@ -409,18 +403,8 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
                 static REGIONS: &[(PooledStr, RegionData)] = &[#(#region_data),*];
 
                 static REGIONS_BROWSERS: &[u8] = include_bytes!("caniuse-region-browsers.bin");
-                static REGIONS_VERSIONS: &[U32; #versions_len / core::mem::size_of::<U32>()] = unsafe {
-                    &core::mem::transmute::<
-                        [u8; #versions_len],
-                        [U32; #versions_len / core::mem::size_of::<U32>()]
-                    >(*include_bytes!("caniuse-region-versions.u32seq"))
-                };
-                static REGIONS_USAGES: &[U32; #usages_len / core::mem::size_of::<U32>()] = unsafe {
-                    &core::mem::transmute::<
-                        [u8; #usages_len],
-                        [U32; #usages_len / core::mem::size_of::<U32>()]
-                    >(*include_bytes!("caniuse-region-usages.u32seq"))
-                };
+                static REGIONS_VERSIONS: &[u32] = &[#(#versions),*];
+                static REGIONS_USAGES: &[u32] = &[#(#region_usages_bits),*];
             }.to_string()
         )?;
     }
@@ -599,20 +583,6 @@ fn run_node(script: &str) -> Result<String> {
         anyhow::bail!("node failed: {}", String::from_utf8_lossy(&out.stderr));
     }
     Ok(String::from_utf8(out.stdout)?)
-}
-
-fn write_u32(path: String, iter: impl Iterator<Item = u32>) -> io::Result<usize> {
-    let fd = fs::File::create(path)?;
-    let mut fd = io::BufWriter::new(fd);
-    let mut n = 0;
-
-    for b in iter {
-        fd.write_all(&b.to_le_bytes())?;
-        n += 4;
-    }
-
-    fd.flush()?;
-    Ok(n)
 }
 
 #[derive(Default)]

--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -43,7 +43,6 @@ struct Caniuse {
 
 #[derive(Deserialize)]
 struct Agent {
-    usage_global: BTreeMap<String, f32>,
     version_list: Vec<VersionDetail>,
 }
 
@@ -261,77 +260,50 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
         )?;
     }
 
-    // caniuse usage
-    {
-        let mut global_usage = Vec::new();
-        for (name, agent) in &data.agents {
-            let name_str_id = strpool.insert(name);
-            for (version, usage) in &agent.usage_global {
-                let version_str_id = strpool.insert(version);
-                global_usage.push((name_str_id, version_str_id, usage));
-            }
-        }
-
-        global_usage.sort_unstable_by(|(.., a), (.., b)| b.total_cmp(a));
-        let push_usage = global_usage
-            .into_iter()
-            .map(|(name_str_id, version_str_id, usage)| {
-                quote! {
-                    (
-                        PooledStr(#name_str_id),
-                        PooledStr(#version_str_id),
-                        #usage
-                    )
-                }
-            });
-        fs::write(
-            format!("{OUT_DIR}/caniuse-global-usage.rs"),
-            quote! {
-                &[#(#push_usage),*]
-            }
-            .to_string(),
-        )?;
-    }
-
     // caniuse features
     {
         let mut features = Vec::new();
         let mut stats = Vec::new();
-        let mut versions = Vec::new();
-        let mut flags = Vec::new();
+        let mut flags: Vec<u8> = Vec::new();
 
         for (name, feature) in &data.data {
             let start = stats.len();
+            // `feature.stats` is keyed by browser name, so the browsers of one feature
+            // already come out in the order `Feature::get` binary searches for.
             for (browser, ver) in &feature.stats {
-                let mut list = ver
-                    .iter()
-                    .map(|(version, flags)| {
-                        let version_str_id = strpool.insert(version);
+                let agent = data.agents.get(browser).ok_or_else(|| {
+                    anyhow::anyhow!("feature `{name}`: unknown browser `{browser}`")
+                })?;
+                // caniuse states every feature for every version of a browser, so no
+                // versions are stored here at all: the flags line up with the browser's
+                // own version list, position by position.
+                anyhow::ensure!(
+                    agent.version_list.len() == ver.len()
+                        && agent
+                            .version_list
+                            .iter()
+                            .all(|version| ver.contains_key(&version.version)),
+                    "feature `{name}` does not cover every version of `{browser}`"
+                );
 
-                        let mut bit: u8 = 0;
-                        if flags.contains('y') {
-                            bit |= 1;
-                        }
-                        if flags.contains('a') {
-                            bit |= 2;
-                        }
-                        (version_str_id, bit)
-                    })
-                    .collect::<Vec<_>>();
-
-                // we only use `.get()`, so the original order does not need to be preserved here
-                list.sort_by_key(|(x, _)| strpool.get(*x));
-
-                let start = versions.len();
-                versions.extend(list.iter().map(|(x, _)| *x));
-                flags.extend(list.iter().map(|(_, y)| *y));
-                let end = versions.len();
-
-                stats.push((browser.as_str(), start, end));
+                flags.extend(agent.version_list.iter().map(|version| {
+                    let support = &ver[&version.version];
+                    let mut bit: u8 = 0;
+                    if support.contains('y') {
+                        bit |= 1;
+                    }
+                    if support.contains('a') {
+                        bit |= 2;
+                    }
+                    bit
+                }));
+                stats.push(browser.as_str());
             }
             let end = stats.len();
-
-            stats[start..end].sort_by_key(|(browser, ..)| *browser);
+            anyhow::ensure!(
+                stats[start..end].is_sorted(),
+                "feature `{name}`: browsers must be in name order"
+            );
 
             let name_str_id = strpool.insert(name);
             features.push((name_str_id, start, end));
@@ -339,15 +311,10 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
 
         features.sort_by_key(|(name, ..)| strpool.get(*name));
 
-        let (stats_name, stats_list): (Vec<_>, Vec<_>) = stats
+        let stats_name = stats
             .iter()
-            .map(|(browser, start, end)| {
-                let browser = encode_browser_name(browser);
-                let start: u32 = (*start).try_into().unwrap();
-                let end: u32 = (*end).try_into().unwrap();
-                (browser, [start, end])
-            })
-            .unzip();
+            .map(|browser| encode_browser_name(browser))
+            .collect::<Vec<_>>();
         let features = features.iter().flat_map(|(name_str_id, start, end)| {
             let start: u32 = (*start).try_into().unwrap();
             let end: u32 = (*end).try_into().unwrap();
@@ -358,15 +325,6 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
                 )
             }
         });
-
-        let version_store_len = write_u32(
-            format!("{OUT_DIR}/caniuse-feature-versionstore.u32seq"),
-            versions.iter().copied(),
-        )?;
-        let version_index_len = write_u32(
-            format!("{OUT_DIR}/caniuse-feature-versionindex.u32seq"),
-            stats_list.iter().flatten().copied(),
-        )?;
 
         fs::write(
             format!("{OUT_DIR}/caniuse-feature-flags.bin"),
@@ -381,23 +339,6 @@ fn build_caniuse(strpool: &mut StrPool) -> Result<()> {
             format!("{OUT_DIR}/caniuse-feature-matching.rs"),
             quote! {
                 static FEATURES: &[(PooledStr, Feature)] = &[#(#features),*];
-
-                // # Safety
-                //
-                // We do the transmute at const context,
-                // and the size and alignment are already checked and guaranteed by compiler.
-                static FEATURES_STAT_VERSION_STORE: &[U32; #version_store_len / core::mem::size_of::<U32>()] = unsafe {
-                    &core::mem::transmute::<
-                        [u8; #version_store_len],
-                        [U32; #version_store_len / core::mem::size_of::<U32>()]
-                    >(*include_bytes!("caniuse-feature-versionstore.u32seq"))
-                };
-                static FEATURES_STAT_VERSION_INDEX: &[PairU32; #version_index_len / core::mem::size_of::<PairU32>()] = unsafe {
-                    &core::mem::transmute::<
-                        [u8; #version_index_len],
-                        [PairU32; #version_index_len / core::mem::size_of::<PairU32>()]
-                    >(*include_bytes!("caniuse-feature-versionindex.u32seq"))
-                };
 
                 static FEATURES_STAT_FLAGS: &[u8] = include_bytes!("caniuse-feature-flags.bin");
                 static FEATURES_STAT_BROWSERS: &[u8] = include_bytes!("caniuse-feature-browsers.bin");
@@ -497,7 +438,6 @@ const result = { agents: {}, data: {} };
 for (const [name, agent] of Object.entries(agents)) {
     const releaseDate = agent.release_date || {};
     result.agents[name] = {
-        usage_global: agent.usage_global,
         version_list: (agent.versions || []).filter(v => v != null).map(v => ({
             version: v,
             global_usage: agent.usage_global[v] || 0,


### PR DESCRIPTION
## Summary

This reduces the generated data footprint by removing information that can already be derived from the data we keep.

`CANIUSE_GLOBAL_USAGE` was redundant because `VersionDetail` already contains `global_usage`, so it can be derived directly from `CANIUSE_BROWSERS`. `FEATURES_STAT_VERSION_STORE` and `FEATURES_STAT_VERSION_INDEX` were also redundant: caniuse provides a state for every feature/version pair, so `VERSION_LIST` can be derived from the generated feature data. `generate-data` now checks this invariant and fails the build if it no longer holds.

To keep `VersionList::get` efficient after this change, it now uses a version-to-position map instead of storing the redundant version data.

Separately, this removes the `U32` wrapper. `REGIONS_VERSIONS` and `REGIONS_USAGES` are now emitted directly as `&[u32]` literals; the wrapper's const transmute provided no size or runtime benefit and only introduced unnecessary `unsafe`.

## Result

The result is a substantially smaller binary, while `supports` also gets faster:

| | main | this branch |
| --- | ---: | ---: |
| binary size | 3,712,600 B | 2,058,376 B (−45%) |
| `supports …` × 800 | 114–120 ms | 86–90 ms (−25%) |
| `cover … in <region>` × 600 | 0.84–1.00 ms | 0.84–0.89 ms |
| `defaults` / `last 2 versions` × 600 | 4.7–5.6 ms | 5.2–5.3 ms |
| `browserslist-data` rebuild | 365 ms | 429 ms |